### PR TITLE
Fix login page UI + custom auth domain

### DIFF
--- a/app/src/pages/management/Login.svelte
+++ b/app/src/pages/management/Login.svelte
@@ -628,7 +628,7 @@
 {/if}
 
 <div class="h-full overflow-y-auto">
-	<div class="container mx-auto max-w-xl md:max-w-3xl flex flex-col justify-center gap-4">
+	<div class="container mx-auto max-w-xl md:max-w-3xl flex flex-col justify-center gap-4 min-h-full">
 		{#if !user || !$user.token}
 			<!-- Create Account -->
 			{#if view === "create"}
@@ -695,15 +695,15 @@
 					<div>
 						<Label for="password">Password</Label>
 						<Input id="password" bind:value={password} type="password" disabled={loading} />
+						<button
+							type="button"
+							class="text-xs text-blue-500 hover:underline mt-1"
+							onclick={forgotPassword}
+							disabled={loading}>Forgot password?</button
+						>
 					</div>
 					<Button type="submit" disabled={loading}>Log In</Button>
 				</form>
-				<button
-					type="button"
-					class="text-sm text-blue-500 hover:underline w-fit"
-					onclick={forgotPassword}
-					disabled={loading}>Forgot password?</button
-				>
 				<Button onclick={() => (view = "create")} disabled={loading} outline>Create Account</Button>
 
 				<p>Or</p>

--- a/app/src/util/firebase.ts
+++ b/app/src/util/firebase.ts
@@ -20,7 +20,7 @@ import {
 // be swapped in here once their DNS + Firebase Hosting verification is set up.
 const PROD_CONFIG = {
 	apiKey: "AIzaSyBrpZ3mQfa8Br1b-TXii01R4aQ8f9RDIFk",
-	authDomain: "fta-buddy.firebaseapp.com",
+	authDomain: "auth.ftabuddy.com",
 	projectId: "fta-buddy",
 	storageBucket: "fta-buddy.firebasestorage.app",
 	messagingSenderId: "668109512883",


### PR DESCRIPTION
Fixes for the login page after the Firebase migration:

- **Vertical centering** — content was pinned to the top. The container had `justify-center` but no height to center against; added `min-h-full` so it fills the (full-height) parent and centers.
- **"Forgot password?" placement** — moved it to directly under the password field in small font (`text-xs`), inside the form. It was previously stranded between the Log In and Create Account buttons with too much margin.
- **Custom auth domain** — `authDomain` → `auth.ftabuddy.com`, so the Google sign-in popup shows our domain instead of `fta-buddy.firebaseapp.com`. The domain's Firebase Hosting cert is live (verified `auth.ftabuddy.com` in the served cert SAN), so the flip is safe.

Dev stays on `fta-buddy-dev.firebaseapp.com` for now (its custom-domain cert isn't provisioned yet).

svelte-check clean, app build succeeds.