### PR TITLE
Add Cheesy Arena as a selectable field data source

### DIFF
--- a/app/src/components/host/StepExtensionSetup.svelte
+++ b/app/src/components/host/StepExtensionSetup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button, Indicator, Input, Select, Toggle } from "flowbite-svelte";
+	import { Button, Indicator, Select, Toggle } from "flowbite-svelte";
 	import { onMount } from "svelte";
 	import { navigate } from "../../router";
 	import { hostWizardStore } from "../../stores/hostWizard";
@@ -16,11 +16,12 @@
 	let useSignalR = $state($hostWizardStore.useSignalR ?? false);
 	let fmsApiEnabled = $state($hostWizardStore.fmsApiEnabled ?? true);
 	let sourceMode = $state<"fms" | "cheesy">($hostWizardStore.sourceMode ?? "fms");
-	let cheesyHost = $state($hostWizardStore.cheesyHost ?? "10.0.100.5:8080");
+	// Cheesy Arena's host is fixed; the extension is hard-coded to this address.
+	const CHEESY_HOST = "10.0.100.5:8080";
 
 	$effect(() => {
 		window.postMessage(
-			{ source: "page", type: "enable", fieldMonitor, useSignalR, fmsApiEnabled, sourceMode, cheesyHost },
+			{ source: "page", type: "enable", fieldMonitor, useSignalR, fmsApiEnabled, sourceMode },
 			"*",
 		);
 	});
@@ -63,7 +64,7 @@
 	});
 
 	function advance() {
-		hostWizardStore.set({ notepadOnly: !fieldMonitor, useSignalR, fmsApiEnabled, sourceMode, cheesyHost, teams });
+		hostWizardStore.set({ notepadOnly: !fieldMonitor, useSignalR, fmsApiEnabled, sourceMode, teams });
 		navigate("/manage/host/create");
 	}
 </script>
@@ -81,7 +82,7 @@
 		FTA Buddy needs the Chrome extension installed and connected to your field system
 		{#if sourceMode === "cheesy"}
 			(Cheesy Arena at
-			<code class="bg-neutral-200 dark:bg-neutral-900 px-2 py-0.5 rounded-lg">{cheesyHost}</code>)
+			<code class="bg-neutral-200 dark:bg-neutral-900 px-2 py-0.5 rounded-lg">{CHEESY_HOST}</code>)
 		{:else}
 			(FMS at
 			<code class="bg-neutral-200 dark:bg-neutral-900 px-2 py-0.5 rounded-lg">10.0.100.5</code>)
@@ -119,7 +120,6 @@
 									useSignalR,
 									fmsApiEnabled,
 									sourceMode,
-									cheesyHost,
 								},
 								"*",
 							)}>Enable</button
@@ -167,18 +167,6 @@
 					<option value="cheesy">Cheesy Arena</option>
 				</Select>
 			</div>
-
-			{#if sourceMode === "cheesy"}
-				<div class="flex items-center justify-between border-t border-neutral-700 pt-3">
-					<div>
-						<p class="font-semibold">Cheesy Arena Host</p>
-						<p class="text-sm text-gray-400">
-							Host and port of the Cheesy Arena web server (e.g. <code>10.0.100.5:8080</code>).
-						</p>
-					</div>
-					<Input bind:value={cheesyHost} placeholder="10.0.100.5:8080" class="ml-4 w-44 shrink-0" />
-				</div>
-			{/if}
 		</div>
 
 		<!-- Card 1: Field Monitor -->

--- a/app/src/components/host/StepExtensionSetup.svelte
+++ b/app/src/components/host/StepExtensionSetup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button, Indicator, Toggle } from "flowbite-svelte";
+	import { Button, Indicator, Input, Select, Toggle } from "flowbite-svelte";
 	import { onMount } from "svelte";
 	import { navigate } from "../../router";
 	import { hostWizardStore } from "../../stores/hostWizard";
@@ -15,9 +15,14 @@
 	let fieldMonitor = $state(!$hostWizardStore.notepadOnly);
 	let useSignalR = $state($hostWizardStore.useSignalR ?? false);
 	let fmsApiEnabled = $state($hostWizardStore.fmsApiEnabled ?? true);
+	let sourceMode = $state<"fms" | "cheesy">($hostWizardStore.sourceMode ?? "fms");
+	let cheesyHost = $state($hostWizardStore.cheesyHost ?? "10.0.100.5:8080");
 
 	$effect(() => {
-		window.postMessage({ source: "page", type: "enable", fieldMonitor, useSignalR, fmsApiEnabled }, "*");
+		window.postMessage(
+			{ source: "page", type: "enable", fieldMonitor, useSignalR, fmsApiEnabled, sourceMode, cheesyHost },
+			"*",
+		);
 	});
 
 	let canAdvance = $derived(
@@ -58,7 +63,7 @@
 	});
 
 	function advance() {
-		hostWizardStore.set({ notepadOnly: !fieldMonitor, useSignalR, fmsApiEnabled, teams });
+		hostWizardStore.set({ notepadOnly: !fieldMonitor, useSignalR, fmsApiEnabled, sourceMode, cheesyHost, teams });
 		navigate("/manage/host/create");
 	}
 </script>
@@ -73,8 +78,14 @@
 	<h1 class="text-3xl font-bold mb-4">Extension Setup</h1>
 
 	<p class="text-lg mb-6">
-		FTA Buddy needs the Chrome extension installed and connected to FMS at
-		<code class="bg-neutral-200 dark:bg-neutral-900 px-2 py-0.5 rounded-lg">10.0.100.5</code>
+		FTA Buddy needs the Chrome extension installed and connected to your field system
+		{#if sourceMode === "cheesy"}
+			(Cheesy Arena at
+			<code class="bg-neutral-200 dark:bg-neutral-900 px-2 py-0.5 rounded-lg">{cheesyHost}</code>)
+		{:else}
+			(FMS at
+			<code class="bg-neutral-200 dark:bg-neutral-900 px-2 py-0.5 rounded-lg">10.0.100.5</code>)
+		{/if}
 		to stream live field data. Make sure you have the FTA's permission to connect to run this software.
 	</p>
 
@@ -101,7 +112,15 @@
 						class="text-blue-400 hover:underline"
 						onclick={() =>
 							window.postMessage(
-								{ source: "page", type: "enable", fieldMonitor, useSignalR, fmsApiEnabled },
+								{
+									source: "page",
+									type: "enable",
+									fieldMonitor,
+									useSignalR,
+									fmsApiEnabled,
+									sourceMode,
+									cheesyHost,
+								},
 								"*",
 							)}>Enable</button
 					>
@@ -133,20 +152,49 @@
 	</div>
 
 	<div class="flex flex-col gap-4 mb-6">
+		<!-- Card 0: Field System -->
+		<div class="flex flex-col gap-3 border border-neutral-700 rounded-xl p-4">
+			<div class="flex items-center justify-between">
+				<div>
+					<p class="font-semibold">Field System</p>
+					<p class="text-sm text-gray-400">
+						The field management system at your event. Choose Cheesy Arena if you are not running official
+						FMS.
+					</p>
+				</div>
+				<Select bind:value={sourceMode} class="ml-4 w-44 shrink-0">
+					<option value="fms">FMS</option>
+					<option value="cheesy">Cheesy Arena</option>
+				</Select>
+			</div>
+
+			{#if sourceMode === "cheesy"}
+				<div class="flex items-center justify-between border-t border-neutral-700 pt-3">
+					<div>
+						<p class="font-semibold">Cheesy Arena Host</p>
+						<p class="text-sm text-gray-400">
+							Host and port of the Cheesy Arena web server (e.g. <code>10.0.100.5:8080</code>).
+						</p>
+					</div>
+					<Input bind:value={cheesyHost} placeholder="10.0.100.5:8080" class="ml-4 w-44 shrink-0" />
+				</div>
+			{/if}
+		</div>
+
 		<!-- Card 1: Field Monitor -->
 		<div class="flex flex-col gap-3 border border-neutral-700 rounded-xl p-4">
 			<div class="flex items-center justify-between">
 				<div>
 					<p class="font-semibold">Field Monitor</p>
 					<p class="text-sm text-gray-400">
-						Streams real-time field data from FMS to your device, including robot connection status, battery
-						levels, and cycle timing.
+						Streams real-time field data to your device, including robot connection status, battery levels,
+						and cycle timing.
 					</p>
 				</div>
 				<Toggle bind:checked={fieldMonitor} class="ml-4 shrink-0" />
 			</div>
 
-			{#if fieldMonitor}
+			{#if fieldMonitor && sourceMode === "fms"}
 				<div class="flex items-center justify-between border-t border-neutral-700 pt-3">
 					<div>
 						<p class="font-semibold">Use SignalR</p>

--- a/app/src/stores/hostWizard.ts
+++ b/app/src/stores/hostWizard.ts
@@ -4,5 +4,7 @@ export const hostWizardStore = writable({
 	notepadOnly: false,
 	useSignalR: false,
 	fmsApiEnabled: true,
+	sourceMode: "fms" as "fms" | "cheesy",
+	cheesyHost: "10.0.100.5:8080",
 	teams: [] as number[],
 });

--- a/app/src/stores/hostWizard.ts
+++ b/app/src/stores/hostWizard.ts
@@ -5,6 +5,5 @@ export const hostWizardStore = writable({
 	useSignalR: false,
 	fmsApiEnabled: true,
 	sourceMode: "fms" as "fms" | "cheesy",
-	cheesyHost: "10.0.100.5:8080",
 	teams: [] as number[],
 });

--- a/extension/CHEESY-ARENA.md
+++ b/extension/CHEESY-ARENA.md
@@ -12,7 +12,8 @@ same `frame` / `cycleTime` / `sendSchedule` events and expose the same REST look
 `background.ts` treats them identically and the server, app, and database are untouched.
 
 - `FmsSource` — official FMS over SignalR (`signalR.ts`) plus the FMS REST API (`fmsapi.ts`).
-- `CheesyArenaSource` — subscribes to Cheesy Arena's `/api/arena/websocket` notifier stream and maps
+- `CheesyArenaSource` — subscribes to Cheesy Arena's `/displays/field_monitor/websocket` notifier
+  stream (the same feed the field monitor display uses; it needs a `displayId` query param) and maps
   it onto the same model. REST lookups hit Cheesy Arena's `/api/matches/...` endpoints.
 
 ### Data mapping (`cheesyArenaMap.ts`)

--- a/extension/CHEESY-ARENA.md
+++ b/extension/CHEESY-ARENA.md
@@ -2,8 +2,8 @@
 
 FTA Buddy can read a [Cheesy Arena](https://github.com/Team254/cheesy-arena) field instead of
 official FMS. Pick the field system in the host wizard's **Extension Setup** step (or set
-`sourceMode` / `cheesyHost` in extension storage). FMS remains the default; nothing changes for FMS
-events.
+`sourceMode` in extension storage). FMS remains the default; nothing changes for FMS
+events. Cheesy Arena is expected at the standard `10.0.100.5:8080`; the host is not configurable.
 
 ## How it works
 
@@ -35,12 +35,11 @@ Match logs are accumulated live from the 2 Hz `arenaStatus` stream (Cheesy Arena
 Cheesy Arena's websocket uses gorilla/websocket's default same-origin check, which rejects the
 extension's `Origin: chrome-extension://<id>` header. The extension uses a `declarativeNetRequest`
 session rule (`cheesyOriginRule.ts`) to strip the Origin header on the websocket upgrade to the
-configured Cheesy Arena host, so the check passes. No Cheesy Arena change is required. This needs the
+Cheesy Arena host, so the check passes. No Cheesy Arena change is required. This needs the
 `declarativeNetRequestWithHostAccess` permission and host access to the Cheesy Arena host.
 
-> The default `cheesyHost` is `10.0.100.5:8080`, covered by the existing `http://10.0.100.5/*` host
-> permission (match patterns ignore the port). If Cheesy Arena runs on a different host, add that host
-> to the extension's `host_permissions`.
+> The Cheesy Arena host is fixed at `10.0.100.5:8080` (`CHEESY_HOST` in `background.ts`), covered by
+> the existing `http://10.0.100.5/*` host permission (match patterns ignore the port).
 
 ## Known limitations
 

--- a/extension/CHEESY-ARENA.md
+++ b/extension/CHEESY-ARENA.md
@@ -1,0 +1,54 @@
+# Cheesy Arena source
+
+FTA Buddy can read a [Cheesy Arena](https://github.com/Team254/cheesy-arena) field instead of
+official FMS. Pick the field system in the host wizard's **Extension Setup** step (or set
+`sourceMode` / `cheesyHost` in extension storage). FMS remains the default; nothing changes for FMS
+events.
+
+## How it works
+
+The extension has a pluggable field data **source** (`extension/src/sources/`). Both sources emit the
+same `frame` / `cycleTime` / `sendSchedule` events and expose the same REST lookups, so
+`background.ts` treats them identically and the server, app, and database are untouched.
+
+- `FmsSource` — official FMS over SignalR (`signalR.ts`) plus the FMS REST API (`fmsapi.ts`).
+- `CheesyArenaSource` — subscribes to Cheesy Arena's `/api/arena/websocket` notifier stream and maps
+  it onto the same model. REST lookups hit Cheesy Arena's `/api/matches/...` endpoints.
+
+### Data mapping (`cheesyArenaMap.ts`)
+
+| FTA Buddy field | Cheesy Arena source |
+| --- | --- |
+| DS state | `Bypass`/`EStop`/`AStop`/`DsLinked`/`WrongStation` on the alliance station + DsConn |
+| radio / rio / code | `DsConn.RadioLinked` / `RioLinked` / `RobotLinked` |
+| enabled | `DsConn.Enabled` + `Auto` (e-stop / a-stop override) |
+| battery / ping / packets | `DsConn.BatteryVoltage` / `DsRobotTripTimeMs` / `MissedPacketCount` |
+| bandwidth / RX / TX / SNR | `WifiStatus.MBits` / `RxRate` / `TxRate` / `SignalNoiseRatio` |
+| radio quality | `WifiStatus.ConnectionQuality` (1-4) |
+| field state | `arenaStatus.MatchState` + `CanStartMatch`, with `matchLoad` = prestart and `scorePosted` = post-result |
+
+Match logs are accumulated live from the 2 Hz `arenaStatus` stream (Cheesy Arena has no FMS-style
+`GetLog`) and uploaded at match end with a deterministic synthetic `fmsMatchId`.
+
+### Cross-origin websocket
+
+Cheesy Arena's websocket uses gorilla/websocket's default same-origin check, which rejects the
+extension's `Origin: chrome-extension://<id>` header. The extension uses a `declarativeNetRequest`
+session rule (`cheesyOriginRule.ts`) to strip the Origin header on the websocket upgrade to the
+configured Cheesy Arena host, so the check passes. No Cheesy Arena change is required. This needs the
+`declarativeNetRequestWithHostAccess` permission and host access to the Cheesy Arena host.
+
+> The default `cheesyHost` is `10.0.100.5:8080`, covered by the existing `http://10.0.100.5/*` host
+> permission (match patterns ignore the port). If Cheesy Arena runs on a different host, add that host
+> to the extension's `host_permissions`.
+
+## Known limitations
+
+Cheesy Arena does not track everything FMS does, so these degrade gracefully:
+
+- No signal/noise dBm, MAC address, or MCS indices (the corresponding graphs/columns are empty).
+- No DS/firmware version data, so version-mismatch warnings never fire.
+- No `GREEN_X` / `WAITING` DS sub-states — a linked DS shows green.
+- No FMS notes / FTA-app two-way sync (FMS only).
+- Schedule ahead/behind and bandwidth-utilization category are approximated from Cheesy Arena's
+  `eventStatus` and `MBits`.

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -2,11 +2,12 @@
     "manifest_version": 3,
     "name": "FTA Buddy",
     "description": "Enable the field monitor and notes sync for FTA Buddy app",
-    "version": "1.26.16",
+    "version": "1.27.0",
     "permissions": [
         "storage",
         "scripting",
-        "alarms"
+        "alarms",
+        "declarativeNetRequestWithHostAccess"
     ],
     "host_permissions": [
         "http://10.0.100.5/*",

--- a/extension/src/app.ts
+++ b/extension/src/app.ts
@@ -9,7 +9,6 @@ const appExtensionData = chrome.runtime.getManifest();
 		useSignalR: boolean,
 		fmsApiEnabled: boolean,
 		sourceMode: "fms" | "cheesy",
-		cheesyHost: string,
 		eventCode: string,
 		eventToken: string,
 		id: string;
@@ -26,7 +25,6 @@ const appExtensionData = chrome.runtime.getManifest();
 				"useSignalR",
 				"fmsApiEnabled",
 				"sourceMode",
-				"cheesyHost",
 				"eventToken",
 				"id",
 			],
@@ -41,7 +39,6 @@ const appExtensionData = chrome.runtime.getManifest();
 				useSignalR = item.useSignalR !== false; // default true
 				fmsApiEnabled = item.fmsApiEnabled !== false; // default true
 				sourceMode = item.sourceMode === "cheesy" ? "cheesy" : "fms"; // default fms
-				cheesyHost = item.cheesyHost ? String(item.cheesyHost) : "";
 				eventToken = String(item.eventToken);
 				id = String(item.id);
 				resolve(void 0);
@@ -61,7 +58,6 @@ const appExtensionData = chrome.runtime.getManifest();
 			useSignalR,
 			fmsApiEnabled,
 			sourceMode,
-			cheesyHost,
 			signalR: enabled,
 			fms: extra?.fms ?? false,
 			id,
@@ -74,10 +70,6 @@ const appExtensionData = chrome.runtime.getManifest();
 		if ("sourceMode" in data) {
 			sourceMode = data.sourceMode === "cheesy" ? "cheesy" : "fms";
 			updates.sourceMode = sourceMode;
-		}
-		if ("cheesyHost" in data) {
-			cheesyHost = String(data.cheesyHost);
-			updates.cheesyHost = cheesyHost;
 		}
 	}
 

--- a/extension/src/app.ts
+++ b/extension/src/app.ts
@@ -8,6 +8,8 @@ const appExtensionData = chrome.runtime.getManifest();
 		fieldMonitor: boolean,
 		useSignalR: boolean,
 		fmsApiEnabled: boolean,
+		sourceMode: "fms" | "cheesy",
+		cheesyHost: string,
 		eventCode: string,
 		eventToken: string,
 		id: string;
@@ -23,6 +25,8 @@ const appExtensionData = chrome.runtime.getManifest();
 				"fieldMonitor",
 				"useSignalR",
 				"fmsApiEnabled",
+				"sourceMode",
+				"cheesyHost",
 				"eventToken",
 				"id",
 			],
@@ -36,6 +40,8 @@ const appExtensionData = chrome.runtime.getManifest();
 				fieldMonitor = Boolean(item.fieldMonitor);
 				useSignalR = item.useSignalR !== false; // default true
 				fmsApiEnabled = item.fmsApiEnabled !== false; // default true
+				sourceMode = item.sourceMode === "cheesy" ? "cheesy" : "fms"; // default fms
+				cheesyHost = item.cheesyHost ? String(item.cheesyHost) : "";
 				eventToken = String(item.eventToken);
 				id = String(item.id);
 				resolve(void 0);
@@ -54,11 +60,25 @@ const appExtensionData = chrome.runtime.getManifest();
 			fieldMonitor,
 			useSignalR,
 			fmsApiEnabled,
+			sourceMode,
+			cheesyHost,
 			signalR: enabled,
 			fms: extra?.fms ?? false,
 			id,
 			...extra,
 		});
+	}
+
+	/** Apply the optional source-mode fields from a page message to the storage update set. */
+	function applySourceFields(data: Record<string, any>, updates: Record<string, any>) {
+		if ("sourceMode" in data) {
+			sourceMode = data.sourceMode === "cheesy" ? "cheesy" : "fms";
+			updates.sourceMode = sourceMode;
+		}
+		if ("cheesyHost" in data) {
+			cheesyHost = String(data.cheesyHost);
+			updates.cheesyHost = cheesyHost;
+		}
 	}
 
 	window.addEventListener("message", async (evt) => {
@@ -84,6 +104,7 @@ const appExtensionData = chrome.runtime.getManifest();
 				fmsApiEnabled = Boolean(evt.data.fmsApiEnabled);
 				updates.fmsApiEnabled = fmsApiEnabled;
 			}
+			applySourceFields(evt.data, updates);
 			await chrome.storage.local.set(updates);
 			// Storage change triggers background restart automatically
 			const fms = await pingFMS();
@@ -106,6 +127,7 @@ const appExtensionData = chrome.runtime.getManifest();
 				fmsApiEnabled = Boolean(evt.data.fmsApiEnabled);
 				updates.fmsApiEnabled = fmsApiEnabled;
 			}
+			applySourceFields(evt.data, updates);
 			await chrome.storage.local.set(updates);
 			// Storage change triggers background restart automatically
 			const fms = await pingFMS();

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,4 +1,3 @@
-import { HubConnectionState } from "@microsoft/signalr";
 import {
 	FTAEventNoteIssueTypeNumeric,
 	FTAEventNoteResolutionTypeNumeric,
@@ -9,19 +8,13 @@ import {
 	type FTANoteRecord,
 	type TournamentLevel,
 } from "../../shared/fmsApiTypes";
-import {
-	addNote,
-	deleteNote,
-	getCurrentMatch,
-	getEventCode,
-	getScheduleBreakdown,
-	getTeamNumbers,
-	setFmsEventPassword,
-	updateNote,
-} from "./fmsapi";
-import { SignalR } from "./signalR";
-import { trpc, updateValues, uploadAllUnimportedMatchLogs } from "./trpc";
+import { addNote, deleteNote, getEventCode, getTeamNumbers, updateNote } from "./fmsapi";
+import { CheesyArenaSource } from "./sources/cheesyArenaSource";
+import { FmsSource } from "./sources/fmsSource";
+import type { FieldDataSource } from "./sources/types";
+import { trpc, updateValues } from "./trpc";
 import { MatchState, MatchStateMap } from "../../shared/types";
+import { clearCheesyOriginRule, setCheesyOriginRule } from "./sources/cheesyOriginRule";
 
 const ALARM_TEAM_POLL = "teamPoll";
 const ALARM_MATCH_IMPORT = "matchImport";
@@ -55,11 +48,13 @@ let outboundNoteSubscription: OutboundSubscription;
 
 const manifestData = chrome.runtime.getManifest();
 export const FMS = "10.0.100.5";
+export const DEFAULT_CHEESY_HOST = "10.0.100.5:8080";
 
-export const signalRConnection = new SignalR(FMS, manifestData.version);
-signalRConnection.on("frame", sendFrame);
-signalRConnection.on("cycleTime", sendCycletime);
-signalRConnection.on("sendSchedule", sendScheduleDetails);
+/**
+ * The active field data source. Rebuilt in {@link start} from the current
+ * settings (FMS over SignalR, or a Cheesy Arena websocket).
+ */
+let source: FieldDataSource | null = null;
 
 export let eventCode: string;
 export let eventToken: string;
@@ -68,6 +63,8 @@ export let id: string;
 export let enabled: boolean;
 export let fieldMonitor: boolean = false;
 export let useSignalR: boolean = true;
+export let sourceMode: "fms" | "cheesy" = "fms";
+export let cheesyHost: string = DEFAULT_CHEESY_HOST;
 export let cloud: boolean;
 export let useDev: boolean;
 export let changed: number;
@@ -81,7 +78,7 @@ async function stop() {
 	stopSchedulePolling();
 	outboundNoteSubscription?.unsubscribe();
 	outboundNoteSubscription = undefined;
-	await signalRConnection.stop();
+	await source?.stop();
 }
 
 async function start() {
@@ -98,6 +95,8 @@ async function start() {
 				"enabled",
 				"fieldMonitor",
 				"useSignalR",
+				"sourceMode",
+				"cheesyHost",
 				"id",
 				"eventToken",
 				"fmsApiEnabled",
@@ -138,6 +137,8 @@ async function start() {
 				fieldMonitor = Boolean(item.fieldMonitor);
 				useSignalR = item.useSignalR !== false; // default true
 				fmsApiEnabled = item.fmsApiEnabled !== false; // default true
+				sourceMode = item.sourceMode === "cheesy" ? "cheesy" : "fms"; // default fms
+				cheesyHost = item.cheesyHost ? String(item.cheesyHost) : DEFAULT_CHEESY_HOST;
 				eventToken = String(item.eventToken);
 				id = String(item.id) || crypto.randomUUID();
 				if (id !== item.id) chrome.storage.local.set({ id });
@@ -154,10 +155,21 @@ async function start() {
 		return;
 	}
 
+	// (Re)build the field data source for the selected mode and wire its events.
+	source = buildSource();
+	source.on("frame", sendFrame);
+	source.on("cycleTime", sendCycletime);
+	source.on("sendSchedule", sendScheduleDetails);
+
+	// Cheesy Arena's websocket enforces a same-origin check; strip the extension
+	// Origin header on requests to it so the connection is accepted.
+	if (sourceMode === "cheesy") await setCheesyOriginRule(cheesyHost);
+	else await clearCheesyOriginRule();
+
 	await pingFMS();
 
 	if (!fieldMonitor) {
-		console.log("Field monitor disabled, skipping SignalR");
+		console.log("Field monitor disabled, skipping realtime source");
 		if (!(eventCode || eventToken)) return;
 		await updateValues();
 		if (fmsApiEnabled) {
@@ -168,9 +180,14 @@ async function start() {
 		return;
 	}
 
-	if (useSignalR) {
+	// The Cheesy Arena source is the realtime feed for its mode; for FMS the
+	// SignalR feed is optional (scraping mode posts frames from a content script).
+	if (sourceMode === "cheesy") {
+		console.log("Starting Cheesy Arena source");
+		await source.start();
+	} else if (useSignalR) {
 		console.log("Starting SignalR");
-		await signalRConnection.start();
+		await source.start();
 	} else {
 		console.log("SignalR disabled, using scraping mode");
 	}
@@ -184,17 +201,26 @@ async function start() {
 		startMatchAutoImport();
 	}
 
-	// Fetch FMS event password from the server and propagate to FTA App API
-	try {
-		const { fmsEventPassword } = await trpc.event.getFmsEventPassword.query();
-		setFmsEventPassword(fmsEventPassword);
-		if (useSignalR) {
-			signalRConnection.on("noteChanged", handleFmsNoteChanged);
+	// FMS-only: fetch the FMS event password and wire two-way note sync.
+	if (source.supportsNotes) {
+		try {
+			const { fmsEventPassword } = await trpc.event.getFmsEventPassword.query();
+			source.setFmsEventPassword(fmsEventPassword);
+			if (useSignalR) {
+				source.on("noteChanged", handleFmsNoteChanged);
+			}
+			startOutboundNoteSync();
+		} catch (err) {
+			console.warn("Could not fetch FMS event password:", err);
 		}
-		startOutboundNoteSync();
-	} catch (err) {
-		console.warn("Could not fetch FMS event password:", err);
 	}
+}
+
+function buildSource(): FieldDataSource {
+	if (sourceMode === "cheesy") {
+		return new CheesyArenaSource(cheesyHost, manifestData.version, () => eventCode);
+	}
+	return new FmsSource(FMS, manifestData.version);
 }
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
@@ -210,16 +236,16 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 		});
 		return true;
 	} else if (msg?.type === "getEventCode") {
-		getEventCode().then((code) => {
-			getTeamNumbers().then((teams) => {
-				sendResponse({
-					source: "ext",
-					version: manifestData.version,
-					type: "eventCode",
-					code,
-					teams,
-					id,
-				});
+		const codeP = source ? source.getEventCode() : getEventCode();
+		const teamsP = source ? source.getTeamNumbers() : getTeamNumbers();
+		Promise.all([codeP, teamsP]).then(([code, teams]) => {
+			sendResponse({
+				source: "ext",
+				version: manifestData.version,
+				type: "eventCode",
+				code,
+				teams,
+				id,
 			});
 		});
 		return true;
@@ -242,6 +268,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 			enabled,
 			fieldMonitor,
 			useSignalR,
+			sourceMode,
+			cheesyHost,
 			fmsApiEnabled,
 			id,
 			fmsApi,
@@ -260,7 +288,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 	}
 
 	if (msg?.type === "getStatuses") {
-		const signalrStatus: HubConnectionState | string = (signalRConnection as any)?.connection?.state ?? "Unknown";
+		const signalrStatus: string = source?.getConnectionStatus() ?? "Unknown";
 
 		sendResponse({
 			signalrStatus,
@@ -273,6 +301,12 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
 export async function pingFMS() {
 	try {
+		// Use the active source when available; fall back to a direct FMS probe
+		// (e.g. for popup pings before the source has been built).
+		if (source) {
+			fmsApi = await source.ping();
+			return fmsApi;
+		}
 		const controller = new AbortController();
 		setTimeout(() => controller.abort(), 500);
 		const res = await fetch(`http://${FMS}/FieldMonitor`, { signal: controller.signal });
@@ -459,7 +493,10 @@ function startOutboundNoteSync() {
 }
 
 async function sendFrame(data: any) {
-	if (!fieldMonitor || !useSignalR) return;
+	// In FMS mode the SignalR feed is gated by useSignalR (scraping mode posts
+	// frames separately); the Cheesy Arena source always feeds frames.
+	if (!fieldMonitor) return;
+	if (sourceMode === "fms" && !useSignalR) return;
 	await trpc.field.post.mutate(
 		eventToken ? { eventToken, ...data, extensionId: id } : { eventCode, ...data, extensionId: id },
 	);
@@ -469,14 +506,14 @@ async function sendCycletime(
 	type: "lastCycleTime" | "prestart" | "matchReady" | "start" | "end" | "refsDone" | "scoresPosted",
 	data: string,
 ) {
-	if (!fieldMonitor) return;
+	if (!fieldMonitor || !source) return;
 	let matchNumber: number, playNumber: number, level: "None" | "Practice" | "Qualification" | "Playoff";
 	if (fmsApiEnabled) {
-		({ matchNumber, playNumber, level } = await getCurrentMatch());
+		({ matchNumber, playNumber, level } = await source.getCurrentMatch());
 	} else {
-		matchNumber = signalRConnection.frame.match;
-		playNumber = signalRConnection.frame.play;
-		level = signalRConnection.frame.level;
+		matchNumber = source.frame.match;
+		playNumber = source.frame.play;
+		level = source.frame.level;
 	}
 	await trpc.cycles.postCycleTime.mutate({
 		eventToken,
@@ -490,21 +527,22 @@ async function sendCycletime(
 }
 
 async function sendScheduleDetails() {
-	const schedule = await getScheduleBreakdown();
+	if (!source) return;
+	const schedule = await source.getScheduleBreakdown();
 	if (schedule.days.length === 0) return;
 	await trpc.cycles.postScheduleDetails.mutate({ eventToken, ...schedule, extensionId: id });
 }
 
 function isMatchRunning(): boolean {
-	return fieldMonitor && useSignalR && MatchStateMap[signalRConnection.frame.field] === MatchState.RUNNING;
+	return fieldMonitor && !!source && MatchStateMap[source.frame.field] === MatchState.RUNNING;
 }
 
 async function pollTeams() {
-	if (!fmsApi || !eventToken || qualsScheduleAvailable) return;
+	if (!fmsApi || !eventToken || qualsScheduleAvailable || !source) return;
 	if (isMatchRunning()) return; // Skip iteration if a match is running
 
 	try {
-		const schedule = await getScheduleBreakdown();
+		const schedule = await source.getScheduleBreakdown();
 		if (schedule.days.length > 0) {
 			console.log("Quals schedule available, stopping team polling");
 			qualsScheduleAvailable = true;
@@ -512,7 +550,7 @@ async function pollTeams() {
 			return;
 		}
 
-		const teams: number[] = await getTeamNumbers();
+		const teams: number[] = await source.getTeamNumbers();
 		if (teams && teams.length > 0) {
 			const result = await trpc.event.syncTeams.mutate({ teamNumbers: teams });
 			if (result.added > 0 || result.removed > 0) {
@@ -537,10 +575,10 @@ function stopTeamPolling() {
 }
 
 async function runMatchAutoImport() {
-	if (!enabled || !eventToken) return;
+	if (!enabled || !eventToken || !source) return;
 	if (isMatchRunning()) return; // Skip iteration if a match is running
 	try {
-		await uploadAllUnimportedMatchLogs();
+		await source.uploadAllUnimportedMatchLogs();
 	} catch (err) {
 		console.warn("Match auto-import error:", err);
 	}

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -48,7 +48,8 @@ let outboundNoteSubscription: OutboundSubscription;
 
 const manifestData = chrome.runtime.getManifest();
 export const FMS = "10.0.100.5";
-export const DEFAULT_CHEESY_HOST = "10.0.100.5:8080";
+/** Cheesy Arena's standard host:port. Not user-configurable. */
+export const CHEESY_HOST = "10.0.100.5:8080";
 
 /**
  * The active field data source. Rebuilt in {@link start} from the current
@@ -64,7 +65,6 @@ export let enabled: boolean;
 export let fieldMonitor: boolean = false;
 export let useSignalR: boolean = true;
 export let sourceMode: "fms" | "cheesy" = "fms";
-export let cheesyHost: string = DEFAULT_CHEESY_HOST;
 export let cloud: boolean;
 export let useDev: boolean;
 export let changed: number;
@@ -96,7 +96,6 @@ async function start() {
 				"fieldMonitor",
 				"useSignalR",
 				"sourceMode",
-				"cheesyHost",
 				"id",
 				"eventToken",
 				"fmsApiEnabled",
@@ -138,7 +137,6 @@ async function start() {
 				useSignalR = item.useSignalR !== false; // default true
 				fmsApiEnabled = item.fmsApiEnabled !== false; // default true
 				sourceMode = item.sourceMode === "cheesy" ? "cheesy" : "fms"; // default fms
-				cheesyHost = item.cheesyHost ? String(item.cheesyHost) : DEFAULT_CHEESY_HOST;
 				eventToken = String(item.eventToken);
 				id = String(item.id) || crypto.randomUUID();
 				if (id !== item.id) chrome.storage.local.set({ id });
@@ -163,7 +161,7 @@ async function start() {
 
 	// Cheesy Arena's websocket enforces a same-origin check; strip the extension
 	// Origin header on requests to it so the connection is accepted.
-	if (sourceMode === "cheesy") await setCheesyOriginRule(cheesyHost);
+	if (sourceMode === "cheesy") await setCheesyOriginRule(CHEESY_HOST);
 	else await clearCheesyOriginRule();
 
 	await pingFMS();
@@ -218,7 +216,7 @@ async function start() {
 
 function buildSource(): FieldDataSource {
 	if (sourceMode === "cheesy") {
-		return new CheesyArenaSource(cheesyHost, manifestData.version, () => eventCode);
+		return new CheesyArenaSource(CHEESY_HOST, manifestData.version, () => eventCode);
 	}
 	return new FmsSource(FMS, manifestData.version);
 }
@@ -269,7 +267,6 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 			fieldMonitor,
 			useSignalR,
 			sourceMode,
-			cheesyHost,
 			fmsApiEnabled,
 			id,
 			fmsApi,

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -216,7 +216,7 @@ async function start() {
 
 function buildSource(): FieldDataSource {
 	if (sourceMode === "cheesy") {
-		return new CheesyArenaSource(CHEESY_HOST, manifestData.version, () => eventCode);
+		return new CheesyArenaSource(CHEESY_HOST, manifestData.version, () => eventCode, id);
 	}
 	return new FmsSource(FMS, manifestData.version);
 }

--- a/extension/src/signalR.ts
+++ b/extension/src/signalR.ts
@@ -16,6 +16,7 @@ import {
 	type SignalRMonitorFrame,
 } from "../../shared/types";
 import { uploadMatchLogs } from "./trpc";
+import { type SourceEventMap, TypedEventEmitter } from "./sources/emitter";
 
 export let signalRConnectionStatus: HubConnectionState = HubConnectionState.Disconnected;
 
@@ -46,37 +47,7 @@ function normalizeFmsNote(raw: any): FTANoteRecord {
 	};
 }
 
-type SignalREventMap = {
-	/** Emitted every time a field monitor frame is processed. */
-	frame: [frame: PartialMonitorFrame];
-	/** Emitted for match cycle time milestones. */
-	cycleTime: [type: "lastCycleTime" | "prestart" | "matchReady" | "start" | "end" | "refsDone" | "scoresPosted", time: string];
-	/** Emitted when the active tournament level changes and the schedule should be re-fetched. */
-	sendSchedule: [];
-	/** Emitted when a note is added/updated/resolved/etc on ftaAppHub. */
-	noteChanged: [action: "added" | "updated" | "reopened" | "resolved" | "deleted", note: FTANoteRecord];
-};
-
-class TypedEventEmitter<T extends Record<string, any[]>> {
-	private _listeners = new Map<keyof T, Set<(...args: any[]) => void>>();
-
-	on<K extends keyof T>(event: K, listener: (...args: T[K]) => void): this {
-		if (!this._listeners.has(event)) this._listeners.set(event, new Set());
-		this._listeners.get(event)!.add(listener as (...args: any[]) => void);
-		return this;
-	}
-
-	off<K extends keyof T>(event: K, listener: (...args: T[K]) => void): this {
-		this._listeners.get(event)?.delete(listener as (...args: any[]) => void);
-		return this;
-	}
-
-	protected emit<K extends keyof T>(event: K, ...args: T[K]): void {
-		this._listeners.get(event)?.forEach((l) => l(...args));
-	}
-}
-
-export class SignalR extends TypedEventEmitter<SignalREventMap> {
+export class SignalR extends TypedEventEmitter<SourceEventMap> {
 	public connection: HubConnection | null = null;
 	public infrastructureConnection: HubConnection | null = null;
 	public ftaAppHubConnection: HubConnection | null = null;

--- a/extension/src/sources/cheesyArenaMap.ts
+++ b/extension/src/sources/cheesyArenaMap.ts
@@ -87,10 +87,12 @@ function dsState(station: CheesyAllianceStation, fieldState: FieldState): DSStat
 	return DSState.RED;
 }
 
-function enableState(station: CheesyAllianceStation): EnableState {
+function enableState(station: CheesyAllianceStation, fieldState: FieldState): EnableState {
 	const dsConn = station.DsConn;
 	if (station.EStop || dsConn?.EStop) return EnableState.ESTOP;
-	if (station.AStop || dsConn?.AStop) return EnableState.ASTOP;
+	// A-stop only latches the robot for the autonomous period; gate on auto to
+	// stay consistent with dsState (an A-stop shown in teleop would contradict it).
+	if ((station.AStop || dsConn?.AStop) && fieldState === FieldState.MATCH_RUNNING_AUTO) return EnableState.ASTOP;
 	if (dsConn?.Enabled) return dsConn.Auto ? EnableState.GREEN_A : EnableState.GREEN_T;
 	return EnableState.RED;
 }
@@ -105,7 +107,7 @@ export function mapRobot(station: CheesyAllianceStation, fieldState: FieldState)
 		radio: dsConn?.RadioLinked ?? false,
 		rio: dsConn?.RioLinked ?? false,
 		code: dsConn?.RobotLinked ?? false,
-		enabled: enableState(station),
+		enabled: enableState(station, fieldState),
 		bwu: wifi?.MBits ?? 0,
 		battery: dsConn?.BatteryVoltage ?? 0,
 		ping: dsConn?.DsRobotTripTimeMs ?? 0,

--- a/extension/src/sources/cheesyArenaMap.ts
+++ b/extension/src/sources/cheesyArenaMap.ts
@@ -1,0 +1,176 @@
+import {
+	DSState,
+	EnableState,
+	FieldState,
+	type FMSLogFrame,
+	type PartialRobotInfo,
+	type TournamentLevel,
+} from "../../../shared/types";
+import {
+	type CheesyAllianceStation,
+	CheesyMatchState,
+	CheesyMatchType,
+} from "./cheesyArenaTypes";
+
+/**
+ * Pure mappers from Cheesy Arena's wire shapes onto FTA-Buddy's internal model.
+ * No side effects, so these can be unit-tested against captured fixtures.
+ */
+
+/** Cheesy Arena ConnectionQuality (1-4) -> FTA-Buddy radio quality label. */
+export function mapConnectionQuality(q: number | undefined): PartialRobotInfo["radioConnectionQuality"] {
+	switch (q) {
+		case 1:
+			return "Caution";
+		case 2:
+			return "Warning";
+		case 3:
+			return "Good";
+		case 4:
+			return "Excellent";
+		default:
+			return null;
+	}
+}
+
+/** Cheesy Arena MatchType -> FTA-Buddy tournament level. */
+export function mapLevel(type: CheesyMatchType): TournamentLevel {
+	switch (type) {
+		case CheesyMatchType.Practice:
+			return "Practice";
+		case CheesyMatchType.Qualification:
+			return "Qualification";
+		case CheesyMatchType.Playoff:
+			return "Playoff";
+		default:
+			return "None";
+	}
+}
+
+/**
+ * Map a Cheesy Arena MatchState to a FTA-Buddy FieldState. Note that the
+ * prestart and scores-posted edges come from the `matchLoad` / `scorePosted`
+ * notifiers (handled in the source), not from MatchState.
+ */
+export function mapFieldState(state: CheesyMatchState, canStartMatch: boolean): FieldState {
+	switch (state) {
+		case CheesyMatchState.PreMatch:
+			return canStartMatch ? FieldState.MATCH_READY : FieldState.MATCH_NOT_READY;
+		case CheesyMatchState.StartMatch:
+		case CheesyMatchState.AutoPeriod:
+			return FieldState.MATCH_RUNNING_AUTO;
+		case CheesyMatchState.PausePeriod:
+			return FieldState.MATCH_TRANSITIONING;
+		case CheesyMatchState.TeleopPeriod:
+			return FieldState.MATCH_RUNNING_TELEOP;
+		case CheesyMatchState.PostMatch:
+			return FieldState.MATCH_OVER;
+		case CheesyMatchState.TimeoutActive:
+		case CheesyMatchState.PostTimeout:
+			return FieldState.MATCH_NOT_READY;
+		default:
+			return FieldState.UNKNOWN;
+	}
+}
+
+function dsState(station: CheesyAllianceStation, fieldState: FieldState): DSState {
+	const dsConn = station.DsConn;
+	if (station.Bypass) return DSState.BYPASS;
+	if (station.EStop || dsConn?.EStop) return DSState.ESTOP;
+	if ((station.AStop || dsConn?.AStop) && fieldState === FieldState.MATCH_RUNNING_AUTO) return DSState.ASTOP;
+	if (dsConn?.DsLinked) {
+		// Cheesy Arena has no GREEN_X / WAITING sub-states; a linked DS in the
+		// wrong station is the one nuance it exposes.
+		if (dsConn.WrongStation) return DSState.MOVE_STATION;
+		return DSState.GREEN;
+	}
+	return DSState.RED;
+}
+
+function enableState(station: CheesyAllianceStation): EnableState {
+	const dsConn = station.DsConn;
+	if (station.EStop || dsConn?.EStop) return EnableState.ESTOP;
+	if (station.AStop || dsConn?.AStop) return EnableState.ASTOP;
+	if (dsConn?.Enabled) return dsConn.Auto ? EnableState.GREEN_A : EnableState.GREEN_T;
+	return EnableState.RED;
+}
+
+/** Map one Cheesy Arena alliance station to a FTA-Buddy robot frame. */
+export function mapRobot(station: CheesyAllianceStation, fieldState: FieldState): PartialRobotInfo {
+	const dsConn = station.DsConn;
+	const wifi = station.WifiStatus;
+	return {
+		number: dsConn?.TeamId || station.Team?.Id || 0,
+		ds: dsState(station, fieldState),
+		radio: dsConn?.RadioLinked ?? false,
+		rio: dsConn?.RioLinked ?? false,
+		code: dsConn?.RobotLinked ?? false,
+		enabled: enableState(station),
+		bwu: wifi?.MBits ?? 0,
+		battery: dsConn?.BatteryVoltage ?? 0,
+		ping: dsConn?.DsRobotTripTimeMs ?? 0,
+		packets: dsConn?.MissedPacketCount ?? 0,
+		// Cheesy Arena does not expose these wireless details.
+		MAC: null,
+		RX: wifi?.RxRate ?? null,
+		RXMCS: null,
+		TX: wifi?.TxRate ?? null,
+		TXMCS: null,
+		SNR: wifi?.SignalNoiseRatio ?? null,
+		noise: null,
+		signal: null,
+		versionmm: false,
+		radioConnected: wifi?.RadioLinked ?? null,
+		radioConnectionQuality: mapConnectionQuality(wifi?.ConnectionQuality),
+	};
+}
+
+/** Build one match-log frame for a station from a live arenaStatus snapshot. */
+export function mapLogFrame(
+	station: CheesyAllianceStation,
+	timeStamp: string,
+	matchTimeSec: number,
+	auto: boolean,
+): FMSLogFrame {
+	const dsConn = station.DsConn;
+	const wifi = station.WifiStatus;
+	return {
+		timeStamp,
+		matchTimeBase: 0,
+		matchTime: matchTimeSec,
+		auto,
+		dsLinkActive: dsConn?.DsLinked ?? false,
+		enabled: dsConn?.Enabled ?? false,
+		aStopPressed: station.AStop || (dsConn?.AStop ?? false),
+		eStopPressed: station.EStop || (dsConn?.EStop ?? false),
+		linkActive: dsConn?.RobotLinked ?? false,
+		radioLink: dsConn?.RadioLinked ?? false,
+		rioLink: dsConn?.RioLinked ?? false,
+		averageTripTime: dsConn?.DsRobotTripTimeMs ?? 0,
+		lostPackets: dsConn?.MissedPacketCount ?? 0,
+		sentPackets: 0,
+		battery: dsConn?.BatteryVoltage ?? 0,
+		brownout: false,
+		signal: null,
+		noise: null,
+		snr: wifi?.SignalNoiseRatio ?? null,
+		txRate: wifi?.TxRate ?? null,
+		txMCS: null,
+		rxRate: wifi?.RxRate ?? null,
+		rxMCS: null,
+		dataRateTotal: wifi?.MBits ?? 0,
+	};
+}
+
+/**
+ * Deterministic synthetic fmsMatchId so the server's id-keyed dedup is stable
+ * across reconnects (Cheesy Arena has no FMS match id).
+ */
+export function buildFmsMatchId(
+	eventCode: string,
+	level: TournamentLevel,
+	matchNumber: number,
+	playNumber: number,
+): string {
+	return `cheesy-${eventCode}-${level}-${matchNumber}-${playNumber}`;
+}

--- a/extension/src/sources/cheesyArenaSource.ts
+++ b/extension/src/sources/cheesyArenaSource.ts
@@ -31,6 +31,19 @@ const RECONNECT_DELAY_MS = 3000;
 const STATION_ENTRIES = Object.entries(CHEESY_STATION_TO_ROBOT) as [CheesyStation, ROBOT][];
 
 /**
+ * A finished match captured at match end. Snapshotting the log buffers and
+ * match context up front means a fast next-match load (which resets the live
+ * buffers) can't clear the logs out from under an in-flight upload.
+ */
+interface MatchSnapshot {
+	ref: MatchRef;
+	fmsMatchId: string;
+	actualStartTime: string;
+	teams: CheesyMatch | undefined;
+	logBuffers: Record<ROBOT, FMSLogFrame[]>;
+}
+
+/**
  * Field data source backed by a Cheesy Arena field (github.com/Team254/cheesy-arena).
  *
  * It subscribes to Cheesy Arena's `/api/arena/websocket` notifier stream and
@@ -61,6 +74,15 @@ export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> impleme
 	private actualStartTime: string | null = null;
 	private logBuffers: Record<ROBOT, FMSLogFrame[]> = this.emptyLogBuffers();
 	private uploadingIds = new Set<string>();
+	private uploadedIds = new Set<string>();
+	private pendingUpload: MatchSnapshot | null = null;
+
+	/**
+	 * Number of finalized plays seen for each `${level}-${matchNumber}` key.
+	 * Cheesy Arena's wire data has no replay index, so we derive a monotonically
+	 * increasing play number locally to keep each replay's fmsMatchId distinct.
+	 */
+	private playCounts = new Map<string, number>();
 
 	constructor(
 		private readonly host: string,
@@ -169,14 +191,19 @@ export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> impleme
 
 	private handleMatchLoad(data: CheesyMatchLoad): void {
 		this.matchLoad = data;
-		this.current = {
-			matchNumber: data.Match.TypeOrder,
-			playNumber: data.IsReplay ? 2 : 1,
-			level: mapLevel(data.Match.Type),
-		};
+		const level = mapLevel(data.Match.Type);
+		const matchNumber = data.Match.TypeOrder;
+		const key = this.matchKey(level, matchNumber);
+		let playNumber = (this.playCounts.get(key) ?? 0) + 1;
+		// If Cheesy Arena flags a replay but we have no local history for it (e.g.
+		// the service worker restarted mid-event), floor at 2 so the replay's
+		// fmsMatchId can't collide with the original play 1.
+		if (data.IsReplay && playNumber < 2) playNumber = 2;
+		this.current = { matchNumber, playNumber, level };
 		// A freshly loaded match is the Cheesy Arena analog of FMS prestart-complete.
 		this.scoresPosted = false;
 		this.actualStartTime = null;
+		this.pendingUpload = null;
 		this.logBuffers = this.emptyLogBuffers();
 		this.frame.field = FieldState.PRESTART_COMPLETED;
 		this.frame.match = this.current.matchNumber;
@@ -226,7 +253,7 @@ export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> impleme
 				break;
 			case FieldState.MATCH_OVER:
 				this.emit("cycleTime", "end", "");
-				setTimeout(() => this.uploadMatchLogs().catch((err) => console.error("CA log upload failed:", err)), 1500);
+				this.finalizeMatch();
 				break;
 		}
 	}
@@ -235,6 +262,8 @@ export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> impleme
 		this.scoresPosted = true;
 		this.frame.field = FieldState.READY_FOR_POST_RESULT;
 		this.emit("cycleTime", "scoresPosted", "");
+		// Fallback in case the match-over path was missed; uploadedIds dedups so
+		// this won't re-send what finalizeMatch already uploaded.
 		this.uploadMatchLogs().catch((err) => console.error("CA log upload failed:", err));
 	}
 
@@ -353,32 +382,67 @@ export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> impleme
 
 	// #region Match log upload
 
-	public async uploadMatchLogs(): Promise<void> {
+	/**
+	 * Snapshot the just-finished match and upload it. Marking the play finalized
+	 * here (rather than on the next load) means a replay of the same match gets
+	 * the next play number instead of colliding on the same fmsMatchId.
+	 */
+	private finalizeMatch(): void {
+		const snapshot = this.snapshotMatch();
+		if (!snapshot) return;
+		this.pendingUpload = snapshot;
+		this.playCounts.set(this.matchKey(snapshot.ref.level, snapshot.ref.matchNumber), snapshot.ref.playNumber);
+		this.uploadSnapshot(snapshot).catch((err) => console.error("CA log upload failed:", err));
+	}
+
+	/**
+	 * Capture the current match context and log buffers. Returns null when there
+	 * is nothing worth uploading (no event code, or no frames recorded).
+	 */
+	private snapshotMatch(): MatchSnapshot | null {
 		const eventCode = this.eventCodeProvider();
 		if (!eventCode) {
-			console.warn("CA uploadMatchLogs: no event code configured, skipping");
-			return;
+			console.warn("CA snapshotMatch: no event code configured, skipping");
+			return null;
 		}
-		const fmsMatchId = buildFmsMatchId(eventCode, this.current.level, this.current.matchNumber, this.current.playNumber);
-		if (this.uploadingIds.has(fmsMatchId)) return;
-
 		const hasFrames = Object.values(this.logBuffers).some((frames) => frames.length > 0);
 		if (!hasFrames) {
-			console.log(`CA uploadMatchLogs: no frames buffered for ${fmsMatchId}, skipping`);
-			return;
+			console.log("CA snapshotMatch: no frames buffered, skipping");
+			return null;
 		}
+		// handleMatchLoad reassigns this.logBuffers to a fresh object and stops
+		// accumulating once the match is over, so holding this reference is safe.
+		return {
+			ref: { ...this.current },
+			fmsMatchId: buildFmsMatchId(eventCode, this.current.level, this.current.matchNumber, this.current.playNumber),
+			actualStartTime: this.actualStartTime ?? new Date().toISOString(),
+			teams: this.matchLoad?.Match,
+			logBuffers: this.logBuffers,
+		};
+	}
 
-		const teams = this.matchLoad?.Match;
-		this.uploadingIds.add(fmsMatchId);
+	public async uploadMatchLogs(): Promise<void> {
+		const snapshot = this.pendingUpload ?? this.snapshotMatch();
+		if (!snapshot) return;
+		await this.uploadSnapshot(snapshot);
+	}
+
+	private async uploadSnapshot(snap: MatchSnapshot): Promise<void> {
+		if (this.uploadedIds.has(snap.fmsMatchId) || this.uploadingIds.has(snap.fmsMatchId)) return;
+		const eventCode = this.eventCodeProvider();
+		if (!eventCode) return;
+
+		const teams = snap.teams;
+		this.uploadingIds.add(snap.fmsMatchId);
 		try {
 			await trpc.match.putCompressedMatchLogs.mutate({
 				event: eventCode,
-				fmsMatchId,
+				fmsMatchId: snap.fmsMatchId,
 				fmsEventId: eventCode,
-				matchNumber: this.current.matchNumber,
-				playNumber: this.current.playNumber,
-				level: this.current.level,
-				actualStartTime: this.actualStartTime ?? new Date().toISOString(),
+				matchNumber: snap.ref.matchNumber,
+				playNumber: snap.ref.playNumber,
+				level: snap.ref.level,
+				actualStartTime: snap.actualStartTime,
 				teamNumberRed1: teams?.Red1,
 				teamNumberRed2: teams?.Red2,
 				teamNumberRed3: teams?.Red3,
@@ -386,17 +450,18 @@ export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> impleme
 				teamNumberBlue2: teams?.Blue2,
 				teamNumberBlue3: teams?.Blue3,
 				logs: {
-					red1: compressStationLog(this.logBuffers.red1),
-					red2: compressStationLog(this.logBuffers.red2),
-					red3: compressStationLog(this.logBuffers.red3),
-					blue1: compressStationLog(this.logBuffers.blue1),
-					blue2: compressStationLog(this.logBuffers.blue2),
-					blue3: compressStationLog(this.logBuffers.blue3),
+					red1: compressStationLog(snap.logBuffers.red1),
+					red2: compressStationLog(snap.logBuffers.red2),
+					red3: compressStationLog(snap.logBuffers.red3),
+					blue1: compressStationLog(snap.logBuffers.blue1),
+					blue2: compressStationLog(snap.logBuffers.blue2),
+					blue3: compressStationLog(snap.logBuffers.blue3),
 				},
 			});
-			console.log(`CA match logs uploaded for ${fmsMatchId}`);
+			this.uploadedIds.add(snap.fmsMatchId);
+			console.log(`CA match logs uploaded for ${snap.fmsMatchId}`);
 		} finally {
-			this.uploadingIds.delete(fmsMatchId);
+			this.uploadingIds.delete(snap.fmsMatchId);
 		}
 	}
 
@@ -410,6 +475,10 @@ export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> impleme
 	}
 
 	// #region Helpers
+
+	private matchKey(level: TournamentLevel, matchNumber: number): string {
+		return `${level}-${matchNumber}`;
+	}
 
 	private emptyLogBuffers(): Record<ROBOT, FMSLogFrame[]> {
 		return {

--- a/extension/src/sources/cheesyArenaSource.ts
+++ b/extension/src/sources/cheesyArenaSource.ts
@@ -1,0 +1,424 @@
+import { DEFAULT_MONITOR } from "../../../shared/constants";
+import {
+	FieldState,
+	type FMSLogFrame,
+	MatchState,
+	MatchStateMap,
+	type PartialMonitorFrame,
+	ROBOT,
+	type TournamentLevel,
+} from "../../../shared/types";
+import { TypedEventEmitter } from "./emitter";
+import {
+	CHEESY_STATION_TO_ROBOT,
+	type CheesyArenaStatus,
+	type CheesyEventStatus,
+	type CheesyMatch,
+	CheesyMatchState,
+	type CheesyMatchLoad,
+	type CheesyMatchTime,
+	type CheesyMessage,
+	type CheesyStation,
+} from "./cheesyArenaTypes";
+import { buildFmsMatchId, mapFieldState, mapLevel, mapLogFrame, mapRobot } from "./cheesyArenaMap";
+import { compressStationLog, trpc } from "../trpc";
+import type { FieldDataSource, MatchRef, ScheduleResult } from "./types";
+import type { SourceEventMap } from "./emitter";
+
+const RECONNECT_DELAY_MS = 3000;
+
+/** Cheesy Arena station id -> FTA-Buddy robot key, with literal types preserved. */
+const STATION_ENTRIES = Object.entries(CHEESY_STATION_TO_ROBOT) as [CheesyStation, ROBOT][];
+
+/**
+ * Field data source backed by a Cheesy Arena field (github.com/Team254/cheesy-arena).
+ *
+ * It subscribes to Cheesy Arena's `/api/arena/websocket` notifier stream and
+ * maps it onto the same `frame` / `cycleTime` events the FMS source emits, so
+ * `background.ts` treats both identically. REST lookups hit Cheesy Arena's
+ * `/api/...` endpoints. Match logs are accumulated live from the arenaStatus
+ * stream (Cheesy Arena has no FMS-style GetLog) and uploaded at match end.
+ *
+ * Note sync is FMS-only and unsupported here.
+ */
+export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> implements FieldDataSource {
+	public readonly supportsNotes = false;
+	public frame: PartialMonitorFrame = structuredClone(DEFAULT_MONITOR);
+
+	private ws: WebSocket | null = null;
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private stopped = false;
+
+	// Latest notifier state.
+	private matchLoad: CheesyMatchLoad | null = null;
+	private eventStatus: CheesyEventStatus | null = null;
+	private matchTimeSec = 0;
+	private current: MatchRef = { matchNumber: 0, playNumber: 1, level: "None" };
+
+	// Match lifecycle tracking.
+	private prevField: FieldState = FieldState.UNKNOWN;
+	private scoresPosted = false;
+	private actualStartTime: string | null = null;
+	private logBuffers: Record<ROBOT, FMSLogFrame[]> = this.emptyLogBuffers();
+	private uploadingIds = new Set<string>();
+
+	constructor(
+		private readonly host: string,
+		version: string,
+		private readonly eventCodeProvider: () => string,
+	) {
+		super();
+		this.frame.version = version;
+	}
+
+	// #region Lifecycle
+
+	public async start(): Promise<void> {
+		this.stopped = false;
+		this.connect();
+	}
+
+	public async stop(): Promise<void> {
+		this.stopped = true;
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+		if (this.ws) {
+			this.ws.onclose = null;
+			try {
+				this.ws.close();
+			} catch {
+				/* already closing */
+			}
+			this.ws = null;
+		}
+	}
+
+	private connect(): void {
+		if (this.stopped) return;
+		const url = `ws://${this.host}/api/arena/websocket`;
+		console.log(`Connecting to Cheesy Arena (${url})`);
+		let ws: WebSocket;
+		try {
+			ws = new WebSocket(url);
+		} catch (err) {
+			console.error("Cheesy Arena websocket construction failed:", err);
+			this.scheduleReconnect();
+			return;
+		}
+		this.ws = ws;
+
+		ws.onopen = () => console.log("Cheesy Arena websocket connected");
+		ws.onmessage = (ev) => {
+			try {
+				this.handleMessage(JSON.parse(ev.data as string) as CheesyMessage);
+			} catch (err) {
+				console.error("Failed to handle Cheesy Arena message:", err, ev.data);
+			}
+		};
+		ws.onerror = (ev) => console.warn("Cheesy Arena websocket error:", ev);
+		ws.onclose = () => {
+			console.warn("Cheesy Arena websocket closed");
+			this.scheduleReconnect();
+		};
+	}
+
+	private scheduleReconnect(): void {
+		if (this.stopped || this.reconnectTimer) return;
+		this.reconnectTimer = setTimeout(() => {
+			this.reconnectTimer = null;
+			this.connect();
+		}, RECONNECT_DELAY_MS);
+	}
+
+	public getConnectionStatus(): string {
+		switch (this.ws?.readyState) {
+			case WebSocket.CONNECTING:
+				return "Connecting";
+			case WebSocket.OPEN:
+				return "Connected";
+			case WebSocket.CLOSING:
+				return "Disconnecting";
+			default:
+				return "Disconnected";
+		}
+	}
+
+	// #region Message handling
+
+	private handleMessage(msg: CheesyMessage): void {
+		switch (msg.type) {
+			case "arenaStatus":
+				this.handleArenaStatus(msg.data as CheesyArenaStatus);
+				break;
+			case "matchLoad":
+				this.handleMatchLoad(msg.data as CheesyMatchLoad);
+				break;
+			case "matchTime":
+				this.matchTimeSec = (msg.data as CheesyMatchTime).MatchTimeSec;
+				break;
+			case "eventStatus":
+				this.eventStatus = msg.data as CheesyEventStatus;
+				break;
+			case "scorePosted":
+				this.handleScorePosted();
+				break;
+		}
+	}
+
+	private handleMatchLoad(data: CheesyMatchLoad): void {
+		this.matchLoad = data;
+		this.current = {
+			matchNumber: data.Match.TypeOrder,
+			playNumber: data.IsReplay ? 2 : 1,
+			level: mapLevel(data.Match.Type),
+		};
+		// A freshly loaded match is the Cheesy Arena analog of FMS prestart-complete.
+		this.scoresPosted = false;
+		this.actualStartTime = null;
+		this.logBuffers = this.emptyLogBuffers();
+		this.frame.field = FieldState.PRESTART_COMPLETED;
+		this.frame.match = this.current.matchNumber;
+		this.frame.play = this.current.playNumber;
+		this.frame.level = this.current.level;
+		this.prevField = FieldState.PRESTART_COMPLETED;
+		this.emit("cycleTime", "prestart", "");
+		this.emit("sendSchedule");
+	}
+
+	private handleArenaStatus(status: CheesyArenaStatus): void {
+		const baseField = mapFieldState(status.MatchState, status.CanStartMatch);
+		// Keep showing post-result until the next match is loaded.
+		const field =
+			this.scoresPosted && status.MatchState === CheesyMatchState.PostMatch
+				? FieldState.READY_FOR_POST_RESULT
+				: baseField;
+
+		this.frame.field = field;
+		this.frame.match = this.current.matchNumber;
+		this.frame.play = this.current.playNumber;
+		this.frame.level = this.current.level;
+		this.frame.time = this.eventStatus?.EarlyLateMessage || "unk";
+		this.frame.lastCycleTime = this.eventStatus?.CycleTime || "unk";
+
+		for (const [station, robot] of STATION_ENTRIES) {
+			const allianceStation = status.AllianceStations[station];
+			if (allianceStation) this.frame[robot] = mapRobot(allianceStation, field);
+		}
+
+		this.frame.frameTime = Date.now();
+		this.handleFieldTransition(field);
+		this.accumulateLogs(status);
+		this.emit("frame", this.frame);
+	}
+
+	private handleFieldTransition(field: FieldState): void {
+		if (field === this.prevField) return;
+		this.prevField = field;
+		switch (field) {
+			case FieldState.MATCH_READY:
+				this.emit("cycleTime", "matchReady", "");
+				break;
+			case FieldState.MATCH_RUNNING_AUTO:
+				this.actualStartTime = new Date().toISOString();
+				this.emit("cycleTime", "start", "");
+				break;
+			case FieldState.MATCH_OVER:
+				this.emit("cycleTime", "end", "");
+				setTimeout(() => this.uploadMatchLogs().catch((err) => console.error("CA log upload failed:", err)), 1500);
+				break;
+		}
+	}
+
+	private handleScorePosted(): void {
+		this.scoresPosted = true;
+		this.frame.field = FieldState.READY_FOR_POST_RESULT;
+		this.emit("cycleTime", "scoresPosted", "");
+		this.uploadMatchLogs().catch((err) => console.error("CA log upload failed:", err));
+	}
+
+	private accumulateLogs(status: CheesyArenaStatus): void {
+		// Only record while the match is actually running.
+		if (MatchStateMap[this.frame.field] !== MatchState.RUNNING) return;
+		const timeStamp = new Date().toISOString();
+		const auto =
+			status.MatchState === CheesyMatchState.StartMatch || status.MatchState === CheesyMatchState.AutoPeriod;
+		for (const [station, robot] of STATION_ENTRIES) {
+			const allianceStation = status.AllianceStations[station];
+			if (allianceStation) this.logBuffers[robot].push(mapLogFrame(allianceStation, timeStamp, this.matchTimeSec, auto));
+		}
+	}
+
+	// #region REST accessors
+
+	public async ping(): Promise<boolean> {
+		try {
+			const controller = new AbortController();
+			setTimeout(() => controller.abort(), 1000);
+			const res = await fetch(`http://${this.host}/api/matches/qualification`, { signal: controller.signal });
+			return res.ok;
+		} catch {
+			return false;
+		}
+	}
+
+	public async getCurrentMatch(): Promise<MatchRef> {
+		return this.current;
+	}
+
+	public async getTeamNumbers(): Promise<number[]> {
+		const matches = await this.fetchMatches("qualification");
+		const teams = new Set<number>();
+		for (const { Match: m } of matches) {
+			for (const t of [m.Red1, m.Red2, m.Red3, m.Blue1, m.Blue2, m.Blue3]) {
+				if (t > 0) teams.add(t);
+			}
+		}
+		return [...teams];
+	}
+
+	public async getEventCode(): Promise<string> {
+		// Cheesy Arena has no FMS-style event code endpoint; FTA-Buddy already
+		// owns the configured event code, so surface that.
+		return this.eventCodeProvider();
+	}
+
+	public async getScheduleBreakdown(): Promise<ScheduleResult> {
+		const matches = await this.fetchMatches("qualification");
+		const days: ScheduleResult["days"] = [];
+		const matchList: ScheduleResult["matches"] = [];
+		let lastPlayed = 0;
+		let day = -1;
+
+		for (let i = 0; i < matches.length; i++) {
+			const m = matches[i].Match;
+			const startTime = new Date(m.Time);
+			const prev = i > 0 ? matches[i - 1].Match : null;
+			const next = i + 1 < matches.length ? matches[i + 1].Match : null;
+			const today = day in days ? days[day] : null;
+			const todayIsNew = !today || today.date.getDate() !== startTime.getDate();
+
+			matchList.push({ scheduledStartTime: startTime, match: m.TypeOrder, level: "Qualification" });
+
+			const cycleTime = Math.abs(
+				Math.round(
+					prev && !todayIsNew
+						? startTime.getTime() - new Date(prev.Time).getTime()
+						: next
+							? startTime.getTime() - new Date(next.Time).getTime()
+							: 8 * 60 * 1000,
+				) /
+					1000 /
+					60,
+			);
+
+			if (todayIsNew) {
+				day++;
+				days[day] = {
+					date: startTime,
+					start: m.TypeOrder,
+					end: m.TypeOrder,
+					endTime: null,
+					lunch: null,
+					lunchTime: null,
+					cycleTimes: [{ match: m.TypeOrder, minutes: cycleTime }],
+				};
+				if (day - 1 in days && prev) {
+					days[day - 1].end = prev.TypeOrder;
+					days[day - 1].endTime = new Date(prev.Time);
+				}
+			} else {
+				const cur = days[day];
+				if (cycleTime !== cur.cycleTimes[cur.cycleTimes.length - 1].minutes) {
+					cur.cycleTimes.push({ match: m.TypeOrder, minutes: cycleTime });
+				}
+				if (!next) {
+					cur.end = m.TypeOrder;
+					cur.endTime = startTime;
+				}
+			}
+
+			if (m.Status === "complete" || matches[i].Result) lastPlayed = m.TypeOrder;
+		}
+
+		return { days, lastPlayed, matches: matchList };
+	}
+
+	private async fetchMatches(type: "qualification" | "playoff" | "practice") {
+		const res = await fetch(`http://${this.host}/api/matches/${type}`);
+		if (!res.ok) throw new Error(`Cheesy Arena /api/matches/${type} returned ${res.status}`);
+		return (await res.json()) as { Match: CheesyMatch; Result: unknown | null }[];
+	}
+
+	// #region Match log upload
+
+	public async uploadMatchLogs(): Promise<void> {
+		const eventCode = this.eventCodeProvider();
+		if (!eventCode) {
+			console.warn("CA uploadMatchLogs: no event code configured, skipping");
+			return;
+		}
+		const fmsMatchId = buildFmsMatchId(eventCode, this.current.level, this.current.matchNumber, this.current.playNumber);
+		if (this.uploadingIds.has(fmsMatchId)) return;
+
+		const hasFrames = Object.values(this.logBuffers).some((frames) => frames.length > 0);
+		if (!hasFrames) {
+			console.log(`CA uploadMatchLogs: no frames buffered for ${fmsMatchId}, skipping`);
+			return;
+		}
+
+		const teams = this.matchLoad?.Match;
+		this.uploadingIds.add(fmsMatchId);
+		try {
+			await trpc.match.putCompressedMatchLogs.mutate({
+				event: eventCode,
+				fmsMatchId,
+				fmsEventId: eventCode,
+				matchNumber: this.current.matchNumber,
+				playNumber: this.current.playNumber,
+				level: this.current.level,
+				actualStartTime: this.actualStartTime ?? new Date().toISOString(),
+				teamNumberRed1: teams?.Red1,
+				teamNumberRed2: teams?.Red2,
+				teamNumberRed3: teams?.Red3,
+				teamNumberBlue1: teams?.Blue1,
+				teamNumberBlue2: teams?.Blue2,
+				teamNumberBlue3: teams?.Blue3,
+				logs: {
+					red1: compressStationLog(this.logBuffers.red1),
+					red2: compressStationLog(this.logBuffers.red2),
+					red3: compressStationLog(this.logBuffers.red3),
+					blue1: compressStationLog(this.logBuffers.blue1),
+					blue2: compressStationLog(this.logBuffers.blue2),
+					blue3: compressStationLog(this.logBuffers.blue3),
+				},
+			});
+			console.log(`CA match logs uploaded for ${fmsMatchId}`);
+		} finally {
+			this.uploadingIds.delete(fmsMatchId);
+		}
+	}
+
+	public async uploadAllUnimportedMatchLogs(): Promise<void> {
+		// Cheesy Arena logs are accumulated live and uploaded at match end, so
+		// there is nothing to backfill from a REST endpoint.
+	}
+
+	public setFmsEventPassword(): void {
+		// No-op: Cheesy Arena has no FMS event password / note sync.
+	}
+
+	// #region Helpers
+
+	private emptyLogBuffers(): Record<ROBOT, FMSLogFrame[]> {
+		return {
+			[ROBOT.red1]: [],
+			[ROBOT.red2]: [],
+			[ROBOT.red3]: [],
+			[ROBOT.blue1]: [],
+			[ROBOT.blue2]: [],
+			[ROBOT.blue3]: [],
+		};
+	}
+}

--- a/extension/src/sources/cheesyArenaSource.ts
+++ b/extension/src/sources/cheesyArenaSource.ts
@@ -46,11 +46,13 @@ interface MatchSnapshot {
 /**
  * Field data source backed by a Cheesy Arena field (github.com/Team254/cheesy-arena).
  *
- * It subscribes to Cheesy Arena's `/api/arena/websocket` notifier stream and
- * maps it onto the same `frame` / `cycleTime` events the FMS source emits, so
- * `background.ts` treats both identically. REST lookups hit Cheesy Arena's
- * `/api/...` endpoints. Match logs are accumulated live from the arenaStatus
- * stream (Cheesy Arena has no FMS-style GetLog) and uploaded at match end.
+ * It subscribes to Cheesy Arena's `/displays/field_monitor/websocket` notifier
+ * stream (the same feed its own field monitor display uses) and maps it onto the
+ * same `frame` / `cycleTime` events the FMS source emits, so `background.ts`
+ * treats both identically. That endpoint is a Cheesy Arena "display", so it
+ * requires a `displayId` query param. REST lookups hit Cheesy Arena's `/api/...`
+ * endpoints. Match logs are accumulated live from the arenaStatus stream (Cheesy
+ * Arena has no FMS-style GetLog) and uploaded at match end.
  *
  * Note sync is FMS-only and unsupported here.
  */
@@ -88,6 +90,7 @@ export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> impleme
 		private readonly host: string,
 		version: string,
 		private readonly eventCodeProvider: () => string,
+		private readonly displayId: string,
 	) {
 		super();
 		this.frame.version = version;
@@ -119,7 +122,9 @@ export class CheesyArenaSource extends TypedEventEmitter<SourceEventMap> impleme
 
 	private connect(): void {
 		if (this.stopped) return;
-		const url = `ws://${this.host}/api/arena/websocket`;
+		// The field monitor feed is a Cheesy Arena "display" and needs a displayId.
+		const displayId = encodeURIComponent(this.displayId || "fta-buddy");
+		const url = `ws://${this.host}/displays/field_monitor/websocket?displayId=${displayId}`;
 		console.log(`Connecting to Cheesy Arena (${url})`);
 		let ws: WebSocket;
 		try {

--- a/extension/src/sources/cheesyArenaTypes.ts
+++ b/extension/src/sources/cheesyArenaTypes.ts
@@ -1,0 +1,160 @@
+/**
+ * Wire types for Cheesy Arena's `/api/arena/websocket` notifier stream.
+ *
+ * Cheesy Arena (github.com/Team254/cheesy-arena) marshals its Go structs with
+ * no json tags, so every key is the exact PascalCase Go field name. These types
+ * are transcribed from:
+ *   field/arena.go                  (AllianceStation, MatchState)
+ *   field/driver_station_connection.go (DriverStationConnection)
+ *   network/access_point.go         (TeamWifiStatus)
+ *   field/arena_notifiers.go        (the notifier message generators)
+ *   model/match.go                  (Match, MatchType)
+ */
+
+/** Envelope every Cheesy Arena websocket message uses (websocket/websocket.go). */
+export interface CheesyMessage<T = unknown> {
+	type: string;
+	data: T;
+}
+
+/** field/arena.go MatchState enum. */
+export enum CheesyMatchState {
+	PreMatch = 0,
+	StartMatch = 1,
+	AutoPeriod = 2,
+	PausePeriod = 3,
+	TeleopPeriod = 4,
+	PostMatch = 5,
+	TimeoutActive = 6,
+	PostTimeout = 7,
+}
+
+/** model/match.go MatchType enum. */
+export enum CheesyMatchType {
+	Test = 0,
+	Practice = 1,
+	Qualification = 2,
+	Playoff = 3,
+}
+
+/** field/driver_station_connection.go (exported fields only). */
+export interface CheesyDriverStationConnection {
+	TeamId: number;
+	AllianceStation: string;
+	Auto: boolean;
+	Enabled: boolean;
+	EStop: boolean;
+	AStop: boolean;
+	DsLinked: boolean;
+	RadioLinked: boolean;
+	RioLinked: boolean;
+	RobotLinked: boolean;
+	BatteryVoltage: number;
+	DsRobotTripTimeMs: number;
+	MissedPacketCount: number;
+	DsReportedStatusValid: boolean;
+	DsReportedAuto: boolean;
+	DsReportedTeleop: boolean;
+	DsReportedDisabled: boolean;
+	DsReportedEnabled: boolean;
+	SecondsSinceLastRobotLink: number;
+	SentGameData: string;
+	/** Non-empty when the connected team is in the wrong station. */
+	WrongStation: string;
+}
+
+/** network/access_point.go TeamWifiStatus. */
+export interface CheesyWifiStatus {
+	TeamId: number;
+	RadioLinked: boolean;
+	MBits: number;
+	RxRate: number;
+	TxRate: number;
+	SignalNoiseRatio: number;
+	/** 1 = caution, 2 = warning, 3 = good, 4 = excellent. */
+	ConnectionQuality: number;
+}
+
+/** model/team.go (only the fields we read). */
+export interface CheesyTeam {
+	Id: number;
+	Nickname?: string;
+}
+
+/** field/arena.go AllianceStation (exported fields only). */
+export interface CheesyAllianceStation {
+	DsConn: CheesyDriverStationConnection | null;
+	Ethernet: boolean;
+	AStop: boolean;
+	EStop: boolean;
+	Bypass: boolean;
+	Team: CheesyTeam | null;
+	WifiStatus: CheesyWifiStatus;
+	GameData: string;
+}
+
+/** `arenaStatus` notifier (field/arena_notifiers.go generateArenaStatusMessage). */
+export interface CheesyArenaStatus {
+	MatchId: number;
+	AllianceStations: Record<string, CheesyAllianceStation>;
+	/** Embedded MatchState int; marshals under the key "MatchState". */
+	MatchState: CheesyMatchState;
+	CanStartMatch: boolean;
+	AccessPointStatus: string;
+	SwitchStatus: string;
+	RedSCCStatus: string;
+	BlueSCCStatus: string;
+	PlcIsHealthy: boolean;
+	FieldEStop: boolean;
+	PlcArmorBlockStatuses: Record<string, boolean>;
+}
+
+/** `matchTime` notifier (MatchTimeMessage). */
+export interface CheesyMatchTime {
+	MatchState: CheesyMatchState;
+	MatchTimeSec: number;
+}
+
+/** model/match.go Match (only the fields we read). */
+export interface CheesyMatch {
+	Id: number;
+	Type: CheesyMatchType;
+	TypeOrder: number;
+	Time: string;
+	ShortName: string;
+	LongName: string;
+	Status: string;
+	Red1: number;
+	Red2: number;
+	Red3: number;
+	Blue1: number;
+	Blue2: number;
+	Blue3: number;
+}
+
+/** `matchLoad` notifier (field/arena_notifiers.go GenerateMatchLoadMessage). */
+export interface CheesyMatchLoad {
+	Match: CheesyMatch;
+	AllowSubstitution: boolean;
+	IsReplay: boolean;
+	Teams: Record<string, CheesyTeam | null>;
+	Rankings: Record<string, number>;
+}
+
+/** `eventStatus` notifier (field/event_status.go EventStatus, exported fields). */
+export interface CheesyEventStatus {
+	CycleTime: string;
+	EarlyLateMessage: string;
+}
+
+/** The six Cheesy Arena station keys, in the canonical FTA-Buddy ROBOT order. */
+export const CHEESY_STATION_TO_ROBOT = {
+	R1: "red1",
+	R2: "red2",
+	R3: "red3",
+	B1: "blue1",
+	B2: "blue2",
+	B3: "blue3",
+} as const;
+
+export type CheesyStation = keyof typeof CHEESY_STATION_TO_ROBOT;

--- a/extension/src/sources/cheesyArenaTypes.ts
+++ b/extension/src/sources/cheesyArenaTypes.ts
@@ -1,5 +1,5 @@
 /**
- * Wire types for Cheesy Arena's `/api/arena/websocket` notifier stream.
+ * Wire types for Cheesy Arena's `/displays/field_monitor/websocket` notifier stream.
  *
  * Cheesy Arena (github.com/Team254/cheesy-arena) marshals its Go structs with
  * no json tags, so every key is the exact PascalCase Go field name. These types

--- a/extension/src/sources/cheesyOriginRule.ts
+++ b/extension/src/sources/cheesyOriginRule.ts
@@ -1,7 +1,7 @@
 /**
- * Cheesy Arena's `/api/arena/websocket` uses gorilla/websocket's default
- * same-origin check, which rejects the extension's cross-origin upgrade (the
- * service worker sends `Origin: chrome-extension://<id>`). We use a
+ * Cheesy Arena's `/displays/field_monitor/websocket` uses gorilla/websocket's
+ * default same-origin check, which rejects the extension's cross-origin upgrade
+ * (the service worker sends `Origin: chrome-extension://<id>`). We use a
  * declarativeNetRequest session rule to strip the Origin header on the websocket
  * upgrade request to the configured Cheesy Arena host, so the check passes
  * (an absent Origin is treated as same-origin). No Cheesy Arena change needed.
@@ -34,7 +34,7 @@ export async function setCheesyOriginRule(host: string): Promise<void> {
 						],
 					},
 					condition: {
-						urlFilter: `${host}/api/arena/websocket`,
+						urlFilter: `${host}/displays/field_monitor/websocket`,
 						resourceTypes: [chrome.declarativeNetRequest.ResourceType.WEBSOCKET],
 					},
 				},

--- a/extension/src/sources/cheesyOriginRule.ts
+++ b/extension/src/sources/cheesyOriginRule.ts
@@ -1,0 +1,55 @@
+/**
+ * Cheesy Arena's `/api/arena/websocket` uses gorilla/websocket's default
+ * same-origin check, which rejects the extension's cross-origin upgrade (the
+ * service worker sends `Origin: chrome-extension://<id>`). We use a
+ * declarativeNetRequest session rule to strip the Origin header on the websocket
+ * upgrade request to the configured Cheesy Arena host, so the check passes
+ * (an absent Origin is treated as same-origin). No Cheesy Arena change needed.
+ *
+ * Requires the `declarativeNetRequestWithHostAccess` permission and host access
+ * to the Cheesy Arena host.
+ */
+
+const CHEESY_ORIGIN_RULE_ID = 7301;
+
+export async function setCheesyOriginRule(host: string): Promise<void> {
+	if (!chrome.declarativeNetRequest?.updateSessionRules) {
+		console.warn("declarativeNetRequest unavailable; Cheesy Arena websocket may be rejected (origin check)");
+		return;
+	}
+	try {
+		await chrome.declarativeNetRequest.updateSessionRules({
+			removeRuleIds: [CHEESY_ORIGIN_RULE_ID],
+			addRules: [
+				{
+					id: CHEESY_ORIGIN_RULE_ID,
+					priority: 1,
+					action: {
+						type: chrome.declarativeNetRequest.RuleActionType.MODIFY_HEADERS,
+						requestHeaders: [
+							{
+								header: "Origin",
+								operation: chrome.declarativeNetRequest.HeaderOperation.REMOVE,
+							},
+						],
+					},
+					condition: {
+						urlFilter: `${host}/api/arena/websocket`,
+						resourceTypes: [chrome.declarativeNetRequest.ResourceType.WEBSOCKET],
+					},
+				},
+			],
+		});
+	} catch (err) {
+		console.warn("Failed to set Cheesy Arena origin rule:", err);
+	}
+}
+
+export async function clearCheesyOriginRule(): Promise<void> {
+	if (!chrome.declarativeNetRequest?.updateSessionRules) return;
+	try {
+		await chrome.declarativeNetRequest.updateSessionRules({ removeRuleIds: [CHEESY_ORIGIN_RULE_ID] });
+	} catch (err) {
+		console.warn("Failed to clear Cheesy Arena origin rule:", err);
+	}
+}

--- a/extension/src/sources/emitter.ts
+++ b/extension/src/sources/emitter.ts
@@ -1,0 +1,39 @@
+import type { FTANoteRecord } from "../../../shared/fmsApiTypes";
+import type { PartialMonitorFrame } from "../../../shared/types";
+
+/**
+ * Events emitted by any field data source (FMS SignalR, Cheesy Arena, ...).
+ * Keeping this shared lets `background.ts` consume every source identically.
+ */
+export type SourceEventMap = {
+	/** Emitted every time a field monitor frame is processed. */
+	frame: [frame: PartialMonitorFrame];
+	/** Emitted for match cycle time milestones. */
+	cycleTime: [
+		type: "lastCycleTime" | "prestart" | "matchReady" | "start" | "end" | "refsDone" | "scoresPosted",
+		time: string,
+	];
+	/** Emitted when the active tournament level changes and the schedule should be re-fetched. */
+	sendSchedule: [];
+	/** Emitted when a note is added/updated/resolved/etc (FMS ftaAppHub only). */
+	noteChanged: [action: "added" | "updated" | "reopened" | "resolved" | "deleted", note: FTANoteRecord];
+};
+
+export class TypedEventEmitter<T extends Record<string, any[]>> {
+	private _listeners = new Map<keyof T, Set<(...args: any[]) => void>>();
+
+	on<K extends keyof T>(event: K, listener: (...args: T[K]) => void): this {
+		if (!this._listeners.has(event)) this._listeners.set(event, new Set());
+		this._listeners.get(event)!.add(listener as (...args: any[]) => void);
+		return this;
+	}
+
+	off<K extends keyof T>(event: K, listener: (...args: T[K]) => void): this {
+		this._listeners.get(event)?.delete(listener as (...args: any[]) => void);
+		return this;
+	}
+
+	protected emit<K extends keyof T>(event: K, ...args: T[K]): void {
+		this._listeners.get(event)?.forEach((l) => l(...args));
+	}
+}

--- a/extension/src/sources/fmsSource.ts
+++ b/extension/src/sources/fmsSource.ts
@@ -1,0 +1,74 @@
+import {
+	getCurrentMatch,
+	getEventCode,
+	getScheduleBreakdown,
+	getTeamNumbers,
+	setFmsEventPassword,
+} from "../fmsapi";
+import { SignalR } from "../signalR";
+import { uploadAllUnimportedMatchLogs, uploadMatchLogs } from "../trpc";
+import type { FieldDataSource, MatchRef, ScheduleResult } from "./types";
+
+/**
+ * The official FMS source: SignalR realtime stream plus the FMS REST lookups.
+ * This is a thin adapter so `background.ts` can treat FMS and Cheesy Arena
+ * identically through {@link FieldDataSource}. Behaviour is unchanged from the
+ * original direct-`fmsapi` wiring.
+ */
+export class FmsSource extends SignalR implements FieldDataSource {
+	public readonly supportsNotes = true;
+	private readonly fmsHost: string;
+
+	constructor(ip: string, version: string) {
+		super(ip, version);
+		this.fmsHost = ip;
+	}
+
+	/** Narrow SignalR's `Promise<void | [...]>` start return to `Promise<void>`. */
+	public async start(): Promise<void> {
+		await super.start();
+	}
+
+	public async ping(): Promise<boolean> {
+		try {
+			const controller = new AbortController();
+			setTimeout(() => controller.abort(), 500);
+			const res = await fetch(`http://${this.fmsHost}/FieldMonitor`, { signal: controller.signal });
+			return res.ok;
+		} catch {
+			return false;
+		}
+	}
+
+	public getConnectionStatus(): string {
+		return this.connection?.state ?? "Unknown";
+	}
+
+	public getCurrentMatch(): Promise<MatchRef> {
+		return getCurrentMatch();
+	}
+
+	public getScheduleBreakdown(): Promise<ScheduleResult> {
+		return getScheduleBreakdown();
+	}
+
+	public getTeamNumbers(): Promise<number[]> {
+		return getTeamNumbers();
+	}
+
+	public getEventCode(): Promise<string> {
+		return getEventCode();
+	}
+
+	public uploadMatchLogs(): Promise<void> {
+		return uploadMatchLogs();
+	}
+
+	public uploadAllUnimportedMatchLogs(onProgress?: (current: number, total: number) => void): Promise<void> {
+		return uploadAllUnimportedMatchLogs(onProgress);
+	}
+
+	public setFmsEventPassword(password: string | null): void {
+		setFmsEventPassword(password);
+	}
+}

--- a/extension/src/sources/types.ts
+++ b/extension/src/sources/types.ts
@@ -1,0 +1,50 @@
+import type { PartialMonitorFrame, ScheduleBreakdown, TournamentLevel } from "../../../shared/types";
+import type { SourceEventMap, TypedEventEmitter } from "./emitter";
+
+export interface MatchRef {
+	matchNumber: number;
+	playNumber: number;
+	level: TournamentLevel;
+}
+
+export interface ScheduleResult {
+	days: ScheduleBreakdown;
+	lastPlayed: number;
+	matches: { match: number; level: TournamentLevel; scheduledStartTime: Date }[];
+}
+
+/**
+ * A field data source feeds `background.ts` with live field monitor frames,
+ * match cycle milestones, and the REST lookups it needs. Two implementations
+ * exist: {@link import("./fmsSource").FmsSource} (official FMS over SignalR) and
+ * {@link import("./cheesyArenaSource").CheesyArenaSource} (Cheesy Arena websocket).
+ *
+ * It is an event emitter (`frame`/`cycleTime`/`sendSchedule`/`noteChanged`)
+ * plus the accessors background needs, so both sources are interchangeable.
+ */
+export interface FieldDataSource extends TypedEventEmitter<SourceEventMap> {
+	/** Latest assembled monitor frame (kept warm so cycle handlers can read match/level). */
+	readonly frame: PartialMonitorFrame;
+	/** Whether this source supports FMS-style two-way note sync. */
+	readonly supportsNotes: boolean;
+
+	start(): Promise<void>;
+	stop(): Promise<void>;
+	/** True if the underlying field system is reachable. */
+	ping(): Promise<boolean>;
+	/** A short, human-readable connection status for diagnostics. */
+	getConnectionStatus(): string;
+
+	getCurrentMatch(): Promise<MatchRef>;
+	getScheduleBreakdown(): Promise<ScheduleResult>;
+	getTeamNumbers(): Promise<number[]>;
+	getEventCode(): Promise<string>;
+
+	/** Upload logs for the just-finished match. */
+	uploadMatchLogs(): Promise<void>;
+	/** Backfill any played matches the server is missing (FMS only; no-op for live-accumulated sources). */
+	uploadAllUnimportedMatchLogs(onProgress?: (current: number, total: number) => void): Promise<void>;
+
+	/** FMS-only; safe no-op elsewhere. */
+	setFmsEventPassword(password: string | null): void;
+}


### PR DESCRIPTION
## What

Lets the extension read a [Cheesy Arena](https://github.com/Team254/cheesy-arena) field in addition to official FMS, selectable in the host wizard's **Extension Setup** step. FMS stays the default; FMS events are unaffected.

The server, app data model, and database are untouched. This is a data-shape translation: Cheesy Arena exposes nearly identical telemetry over its own websocket, so the work is mapping it onto the same internal frame the FMS path already produces.

## How

Introduces a pluggable field-data-source abstraction in `extension/src/sources/`:

- **`FieldDataSource`** interface + a shared typed event emitter (extracted from `signalR.ts`). Both sources emit the same `frame` / `cycleTime` / `sendSchedule` events and expose the same REST lookups, so `background.ts` treats them identically.
- **`FmsSource`** wraps the existing SignalR + FMS REST path — a pure refactor, FMS behaviour is unchanged.
- **`CheesyArenaSource`** subscribes to Cheesy Arena's `/api/arena/websocket` and maps `arenaStatus` / `matchLoad` / `matchTime` / `eventStatus` onto the frame, cycle-time, and schedule model (`cheesyArenaMap.ts`, kept side-effect-free). Match logs are accumulated live from the 2 Hz stream (Cheesy Arena has no FMS-style `GetLog`) and uploaded at match end with a deterministic synthetic `fmsMatchId`.
- **Cross-origin websocket:** Cheesy Arena's websocket uses gorilla's default same-origin check, which rejects the extension's `Origin: chrome-extension://<id>`. A `declarativeNetRequest` session rule strips the Origin header on the upgrade to the configured CA host, so the check passes with no Cheesy Arena change. Adds the `declarativeNetRequestWithHostAccess` permission.
- **UI:** the Extension Setup step gains a Field System selector (FMS / Cheesy Arena) + a CA host input, plumbed through `app.ts` into extension storage.

Data mapping and limitations are documented in [`extension/CHEESY-ARENA.md`](extension/CHEESY-ARENA.md).

## Limitations

Cheesy Arena doesn't track everything FMS does, so these degrade gracefully: no signal/noise dBm, MAC, or MCS; no version-mismatch warnings; no `GREEN_X`/`WAITING` DS sub-states; no FMS note sync.

## Testing

- `tsc --noEmit` clean for the new/changed extension source; webpack build succeeds.
- `svelte-check` clean for the changed app files.
- End-to-end against a live Cheesy Arena + local server still needs a hands-on run (load + run a match, confirm the field monitor, field-state banner, cycle times, and post-match logs).