### PR TITLE
Release 2.7.8.0: Cheesy Arena welcome mention, drop unofficial-tool warning

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -244,11 +244,6 @@
 		track("page_view", eventCode, { page });
 	});
 
-	let approvalWarningDismissed = $state(localStorage.getItem("approvalWarningDismissed") === "true");
-	function dismissApprovalWarning() {
-		approvalWarningDismissed = true;
-		localStorage.setItem("approvalWarningDismissed", "true");
-	}
 
 	// Settings modal
 
@@ -987,18 +982,6 @@
 			</div>
 		</div>
 	{/if}
-
-	<Modal open={!approvalWarningDismissed} dismissable={false}>
-		{#snippet header()}
-			<h2 class="text-xl font-bold">Unofficial Tool</h2>
-		{/snippet}
-		<p class="text-gray-700 dark:text-gray-300">
-			FTA Buddy is <strong>not approved for use at official FIRST events.</strong> Only use this tool at offseason events.
-		</p>
-		{#snippet footer()}
-			<Button onclick={dismissApprovalWarning}>I Understand</Button>
-		{/snippet}
-	</Modal>
 
 	<div class="flex-1 min-h-0 overflow-auto pb-safe">
 		<SvRouter />

--- a/app/src/components/WelcomeModal.svelte
+++ b/app/src/components/WelcomeModal.svelte
@@ -53,6 +53,10 @@
 				<li>Reference materials and diagrams</li>
 			</ul>
 			<p class="py-1">You can access all features through the sidebar or bottom navigation.</p>
+			<p class="py-1">
+				Running an offseason event on <strong>Cheesy Arena</strong>? The FTA Buddy browser extension can now
+				connect straight to a Cheesy Arena field, so you get live monitoring and match logs without official FMS.
+			</p>
 			{#if $installPrompt}
 				<h2 class="font-bold py-1">Install this App</h2>
 				<p class="py-1">Recommended for the best experience.</p>

--- a/app/src/util/updater.ts
+++ b/app/src/util/updater.ts
@@ -3,7 +3,7 @@ import { eventStore } from "../stores/event";
 import { settingsStore } from "../stores/settings";
 import { userStore } from "../stores/user";
 
-export const LATEST_EXTENSION_VERSION = "1.26.14";
+export const LATEST_EXTENSION_VERSION = "1.26.18";
 
 interface Version {
 	changelog?: string;
@@ -11,6 +11,14 @@ interface Version {
 }
 
 export const VERSIONS: { [key: string]: Version } = {
+	"2.7.8.0": {
+		changelog: `
+        <h1 class="text-lg font-bold">v2.7.8.0</h1>
+        <ul>
+        <li>Cheesy Arena support: the browser extension can now read a Cheesy Arena field directly, so you can run FTA Buddy at offseason events that aren't using official FMS</li>
+        <li>Extension <strong>v1.26.18</strong></li>
+        </ul>`,
+	},
 	"2.7.7.2": {
 		changelog: `
         <h1 class="text-lg font-bold">v2.7.7.2</h1>

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "FTA Buddy",
     "description": "Enable the field monitor and notes sync for FTA Buddy app",
-    "version": "1.27.0",
+    "version": "1.26.18",
     "permissions": [
         "storage",
         "scripting",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"app",
 		"extension"
 	],
-	"version": "2.7.7.2",
+	"version": "2.7.8.0",
 	"description": "",
 	"scripts": {
 		"start": "bun run ./src/index.ts",


### PR DESCRIPTION
Post-merge housekeeping for the Cheesy Arena feature (#131).

## Changes
- **Remove the "Unofficial Tool" modal** — the blocking offseason-only warning is gone from app load.
- **Welcome modal** now mentions Cheesy Arena field support (the extension can read a Cheesy Arena field directly).
- **Changelog / app version** `2.7.7.2` → `2.7.8.0` (minor bump so the changelog actually surfaces to users rather than being treated as a silent patch).
- **`LATEST_EXTENSION_VERSION`** `1.26.14` → `1.26.18` so the app prompts existing users to update.
- **Extension manifest version** `1.27.0` → `1.26.18` — the `27` broke the `1.<year>.<build>` scheme (`26` = 2026); this continues the build sequence past the prior `1.26.17`.

## Verified
- `svelte-check`: no new errors (3 pre-existing `role: "System"` issues unchanged).
- `vite build`: clean.