### PR TITLE
Remote extension config + full popup settings (ext 1.26.19)

### DIFF
--- a/app/src/components/host/StepEventManagement.svelte
+++ b/app/src/components/host/StepEventManagement.svelte
@@ -16,33 +16,48 @@
 	import IntegrationWpaKiosk from "./integrations/IntegrationWpaKiosk.svelte";
 
 	let qrModalOpen = $state(false);
-	let extensionDetected = $state(false);
-	let extensionEnabled = $state(false);
-	let extensionFieldMonitor = $state(false);
-	let extensionUseSignalR = $state(true);
-	let extensionFmsApiEnabled = $state(true);
-	let extensionVersion = $state("");
-	let extensionOutdated = $state(false);
+
+	type ExtensionConfig = {
+		enabled?: boolean;
+		fieldMonitor?: boolean;
+		useSignalR?: boolean;
+		fmsApiEnabled?: boolean;
+		sourceMode?: "fms" | "cheesy";
+		cheesyPort?: number;
+	};
+	type ExtensionSummary = {
+		id: string;
+		version?: string;
+		config?: ExtensionConfig;
+		fmsApi?: boolean;
+		connected: Date;
+		lastFrame: Date;
+	};
+
+	// Connected extensions come from the SERVER (via the extension's live
+	// connection), so this page works from any device - it no longer depends on
+	// the extension being installed in the browser viewing this page.
+	let extensions = $state<ExtensionSummary[]>([]);
+	let activeExtension = $derived(
+		[...extensions].sort((a, b) => new Date(b.lastFrame).getTime() - new Date(a.lastFrame).getTime())[0],
+	);
+	let extensionDetected = $derived(!!activeExtension);
+	let extensionVersion = $derived(activeExtension?.version ?? "");
+	// Only extensions new enough to report their config can be configured remotely.
+	let remoteConfigSupported = $derived(!!activeExtension?.config);
+	let extensionEnabled = $derived(activeExtension?.config?.enabled ?? false);
+	let extensionFieldMonitor = $derived(activeExtension?.config?.fieldMonitor ?? false);
+	let extensionUseSignalR = $derived(activeExtension?.config?.useSignalR ?? true);
+	let extensionFmsApiEnabled = $derived(activeExtension?.config?.fmsApiEnabled ?? true);
+	let extensionOutdated = $derived(!!extensionVersion && extensionVersion < LATEST_EXTENSION_VERSION);
+	let fmsExtensionConnected = $derived(activeExtension?.fmsApi ?? false);
+
 	let extensionConfiguring = $state(false);
 	let extensionConfigured = $state(false);
-	let fmsExtensionConnected = $state(false);
 	let extensionConfigDialogOpen = $state(false);
 	let configFieldMonitor = $state(true);
 	let configUseSignalR = $state(true);
 	let configFmsApiEnabled = $state(true);
-
-	window.addEventListener("message", (event) => {
-		if (event.data?.type === "pong") {
-			extensionDetected = true;
-			extensionVersion = event.data.version ?? "";
-			extensionEnabled = event.data.enabled ?? false;
-			extensionFieldMonitor = event.data.fieldMonitor ?? false;
-			extensionUseSignalR = event.data.useSignalR ?? true;
-			extensionFmsApiEnabled = event.data.fmsApiEnabled ?? true;
-			extensionOutdated = extensionVersion < LATEST_EXTENSION_VERSION;
-			fmsExtensionConnected = event.data.fms ?? false;
-		}
-	});
 
 	async function configureExtension(fieldMonitor: boolean, useSignalR: boolean, fmsApiEnabled: boolean) {
 		extensionConfiguring = true;
@@ -51,23 +66,12 @@
 			const notepadOnly = !fieldMonitor;
 			await trpc.event.setNotepadOnly.mutate({ notepadOnly });
 			eventStore.update((e) => ({ ...e, notepadOnly }));
-			window.postMessage(
-				{
-					source: "page",
-					type: "eventCode",
-					code: $eventStore.code,
-					token: $userStore.eventToken,
-					fieldMonitor,
-					useSignalR,
-					fmsApiEnabled,
-				},
-				"*",
-			);
-			await new Promise((resolve) => setTimeout(resolve, 600));
-			extensionFieldMonitor = fieldMonitor;
-			extensionUseSignalR = useSignalR;
-			extensionFmsApiEnabled = fmsApiEnabled;
+			// Push config through the server to the connected extension(s); works
+			// from any device, unlike the old in-browser postMessage.
+			await trpc.extension.setConfig.mutate({ config: { fieldMonitor, useSignalR, fmsApiEnabled } });
 			extensionConfigured = true;
+		} catch (e) {
+			if (e instanceof Error) toast("Error", e.message);
 		} finally {
 			extensionConfiguring = false;
 		}
@@ -81,7 +85,13 @@
 	}
 
 	onMount(() => {
-		window.postMessage({ source: "page", type: "ping" }, "*");
+		const sub = trpc.extension.statusSubscription.subscribe(undefined, {
+			onData: (data) => {
+				extensions = data;
+			},
+			onError: (err) => console.warn("Extension status subscription error:", err),
+		});
+		return () => sub.unsubscribe();
 	});
 
 	let playoffModeBlocked = $state(false);
@@ -139,8 +149,8 @@
 	<div class="flex items-center gap-3 mb-4">
 		<div class="flex flex-col gap-0.5">
 			<span class="inline-flex gap-2 font-bold">
-				<Indicator color={fmsExtensionConnected ? "green" : "red"} class="my-auto" />
-				{#if fmsExtensionConnected}
+				<Indicator color={extensionDetected ? "green" : "red"} class="my-auto" />
+				{#if extensionDetected}
 					<span class="text-green-500">Extension Connected</span>
 				{:else}
 					<span class="text-red-400">No Extension Connected</span>
@@ -148,7 +158,9 @@
 			</span>
 			{#if extensionDetected}
 				<span class="text-xs text-gray-500">
-					{#if !extensionEnabled}
+					{#if !remoteConfigSupported}
+						Update the extension to configure it from here
+					{:else if !extensionEnabled}
 						Extension not enabled
 					{:else if !extensionFieldMonitor}
 						Field monitor off
@@ -156,6 +168,9 @@
 						SignalR mode
 					{:else}
 						Scraping mode
+					{/if}
+					{#if remoteConfigSupported && extensionFmsApiEnabled}
+						&middot; {fmsExtensionConnected ? "FMS connected" : "FMS not detected"}
 					{/if}
 				</span>
 			{:else}

--- a/app/src/util/updater.ts
+++ b/app/src/util/updater.ts
@@ -3,7 +3,7 @@ import { eventStore } from "../stores/event";
 import { settingsStore } from "../stores/settings";
 import { userStore } from "../stores/user";
 
-export const LATEST_EXTENSION_VERSION = "1.26.18";
+export const LATEST_EXTENSION_VERSION = "1.26.19";
 
 interface Version {
 	changelog?: string;
@@ -11,12 +11,20 @@ interface Version {
 }
 
 export const VERSIONS: { [key: string]: Version } = {
+	"2.7.9.0": {
+		changelog: `
+        <h1 class="text-lg font-bold">v2.7.9.0</h1>
+        <ul>
+        <li>Reconfigure a connected extension from any device - event settings now works through the server, not just the browser the extension is installed in</li>
+        <li>Extension <strong>v1.26.19</strong>: manage every setting, including the field system and Cheesy Arena port, from the popup</li>
+        </ul>
+        `,
+	},
 	"2.7.8.0": {
 		changelog: `
         <h1 class="text-lg font-bold">v2.7.8.0</h1>
         <ul>
-        <li>Added Cheesy Arena support for offseason events not running official FMS</li>
-        <li>Extension <strong>v1.26.18</strong>: read a Cheesy Arena field directly, with a configurable port</li>
+        <li>Added Cheesy Arena support for offseason events not running official FMS, with a configurable port</li>
         </ul>
         `,
 	},

--- a/app/src/util/updater.ts
+++ b/app/src/util/updater.ts
@@ -11,9 +11,9 @@ interface Version {
 }
 
 export const VERSIONS: { [key: string]: Version } = {
-	"2.7.9.0": {
+	"2.7.8.1": {
 		changelog: `
-        <h1 class="text-lg font-bold">v2.7.9.0</h1>
+        <h1 class="text-lg font-bold">v2.7.8.1</h1>
         <ul>
         <li>Reconfigure a connected extension from any device - event settings now works through the server, not just the browser the extension is installed in</li>
         <li>Extension <strong>v1.26.19</strong>: manage every setting, including the field system and Cheesy Arena port, from the popup</li>

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "FTA Buddy",
     "description": "Enable the field monitor and notes sync for FTA Buddy app",
-    "version": "1.26.18",
+    "version": "1.26.19",
     "permissions": [
         "storage",
         "scripting",

--- a/extension/public/menu.html
+++ b/extension/public/menu.html
@@ -337,6 +337,49 @@
 
 			<div class="spaced">
 				<span class="hstack" style="gap: 10px">
+					<span style="font-weight: 700">Field System</span>
+				</span>
+				<select
+					id="sourceMode"
+					style="
+						background: var(--input-bg, #1f2937);
+						color: inherit;
+						border: 1px solid var(--border, #374151);
+						border-radius: 6px;
+						padding: 4px 8px;
+						font: inherit;
+					"
+				>
+					<option value="fms">FMS</option>
+					<option value="cheesy">Cheesy Arena</option>
+				</select>
+			</div>
+
+			<div class="spaced" style="margin-top: 6px; display: none" id="cheesy-port-row">
+				<span class="hstack" style="gap: 10px">
+					<span style="font-weight: 700">Cheesy Port</span>
+					<span style="font-size: 11px; color: var(--muted)">on 10.0.100.5</span>
+				</span>
+				<input
+					id="cheesyPort"
+					type="number"
+					min="1"
+					max="65535"
+					placeholder="8080"
+					style="
+						width: 80px;
+						background: var(--input-bg, #1f2937);
+						color: inherit;
+						border: 1px solid var(--border, #374151);
+						border-radius: 6px;
+						padding: 4px 8px;
+						font: inherit;
+					"
+				/>
+			</div>
+
+			<div class="spaced" style="margin-top: 6px">
+				<span class="hstack" style="gap: 10px">
 					<span style="font-weight: 700">Enabled</span>
 				</span>
 				<label class="switch" aria-label="Enabled">

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -45,6 +45,7 @@ const NOTE_TYPE_TO_FMS_NUMERIC: Record<string, number> = {
 
 type OutboundSubscription = ReturnType<typeof trpc.notes.updateSubscription.subscribe> | undefined;
 let outboundNoteSubscription: OutboundSubscription;
+let extensionConfigSubscription: { unsubscribe: () => void } | undefined;
 
 const manifestData = chrome.runtime.getManifest();
 export const FMS = "10.0.100.5";
@@ -95,6 +96,8 @@ async function stop() {
 	stopSchedulePolling();
 	outboundNoteSubscription?.unsubscribe();
 	outboundNoteSubscription = undefined;
+	extensionConfigSubscription?.unsubscribe();
+	extensionConfigSubscription = undefined;
 	await source?.stop();
 }
 
@@ -189,6 +192,7 @@ async function start() {
 		console.log("Field monitor disabled, skipping realtime source");
 		if (!(eventCode || eventToken)) return;
 		await updateValues();
+		startExtensionConfigSync();
 		if (fmsApiEnabled) {
 			startSchedulePolling();
 			startTeamPolling();
@@ -212,6 +216,7 @@ async function start() {
 	if (!(eventCode || eventToken)) return;
 
 	await updateValues();
+	startExtensionConfigSync();
 	if (fmsApiEnabled) {
 		startSchedulePolling();
 		startTeamPolling();
@@ -238,6 +243,49 @@ function buildSource(): FieldDataSource {
 		return new CheesyArenaSource(cheesyHost(), manifestData.version, () => eventCode, id);
 	}
 	return new FmsSource(FMS, manifestData.version);
+}
+
+// #region Remote config sync
+
+/** The extension settings mirrored to the server for remote configuration. */
+function currentExtensionConfig() {
+	return { enabled, fieldMonitor, useSignalR, fmsApiEnabled, sourceMode, cheesyPort };
+}
+
+/** Report the current config + version to the server so any device can see it. */
+function reportExtensionState() {
+	if (!eventToken) return;
+	trpc.extension.reportState
+		.mutate({ extensionId: id, version: manifestData.version, fmsApi, config: currentExtensionConfig() })
+		.catch((err) => console.warn("Extension reportState failed:", err));
+}
+
+/**
+ * Report current config to the server and subscribe for remote config pushes so
+ * the extension can be reconfigured from any device. A pushed config is written
+ * to chrome.storage.local, whose change listener restarts the extension so the
+ * new settings take effect (and reportState then confirms the applied state).
+ */
+function startExtensionConfigSync() {
+	extensionConfigSubscription?.unsubscribe();
+	reportExtensionState();
+	extensionConfigSubscription = trpc.extension.configSubscription.subscribe(
+		{ extensionId: id },
+		{
+			onData: (config) => {
+				const updates: Record<string, any> = {};
+				if (config.enabled !== undefined) updates.enabled = config.enabled;
+				if (config.fieldMonitor !== undefined) updates.fieldMonitor = config.fieldMonitor;
+				if (config.useSignalR !== undefined) updates.useSignalR = config.useSignalR;
+				if (config.fmsApiEnabled !== undefined) updates.fmsApiEnabled = config.fmsApiEnabled;
+				if (config.sourceMode !== undefined)
+					updates.sourceMode = config.sourceMode === "cheesy" ? "cheesy" : "fms";
+				if (config.cheesyPort !== undefined) updates.cheesyPort = sanitizeCheesyPort(config.cheesyPort);
+				if (Object.keys(updates).length > 0) chrome.storage.local.set(updates);
+			},
+			onError: (err) => console.warn("Extension configSubscription error:", err),
+		},
+	);
 }
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/extension/src/menu.ts
+++ b/extension/src/menu.ts
@@ -11,6 +11,9 @@ const useSignalRInput = document.getElementById("useSignalR") as HTMLInputElemen
 const signalRRow = document.getElementById("signalr-row") as HTMLDivElement;
 const tokenInput = document.getElementById("eventToken") as HTMLInputElement;
 const fmsApiEnabledInput = document.getElementById("fmsApiEnabled") as HTMLInputElement;
+const sourceModeSelect = document.getElementById("sourceMode") as HTMLSelectElement;
+const cheesyPortInput = document.getElementById("cheesyPort") as HTMLInputElement;
+const cheesyPortRow = document.getElementById("cheesy-port-row") as HTMLDivElement;
 const saveButton = document.getElementById("save") as HTMLButtonElement;
 
 const extensionStatusIndicator = document.getElementById("extension-status") as HTMLDivElement;
@@ -60,6 +63,8 @@ function load() {
 			"fieldMonitor",
 			"useSignalR",
 			"fmsApiEnabled",
+			"sourceMode",
+			"cheesyPort",
 		],
 		(item) => {
 			if (
@@ -95,6 +100,9 @@ function load() {
 			useSignalRInput.checked = item.useSignalR !== false; // default true
 			fmsApiEnabledInput.checked = item.fmsApiEnabled !== false; // default true
 			signalRRow.style.display = Boolean(item.fieldMonitor) ? "flex" : "none";
+			sourceModeSelect.value = item.sourceMode === "cheesy" ? "cheesy" : "fms";
+			cheesyPortInput.value = String(item.cheesyPort || 8080);
+			cheesyPortRow.style.display = sourceModeSelect.value === "cheesy" ? "flex" : "none";
 			tokenInput.value = String(item.eventToken);
 			let changed = Number(item.changed);
 
@@ -110,6 +118,8 @@ function load() {
 			fieldMonitorInput.addEventListener("input", handleUpdate);
 			useSignalRInput.addEventListener("input", handleUpdate);
 			fmsApiEnabledInput.addEventListener("input", handleUpdate);
+			sourceModeSelect.addEventListener("input", handleUpdate);
+			cheesyPortInput.addEventListener("input", handleUpdate);
 			if (useDevCheckbox) useDevCheckbox.addEventListener("input", handleUpdate);
 			saveButton.addEventListener("click", handleUpdate);
 			refreshButton.addEventListener("click", () => chrome.runtime.reload());
@@ -230,10 +240,13 @@ function handleUpdate() {
 		useSignalR: useSignalRInput.checked,
 		fmsApiEnabled: fmsApiEnabledInput.checked,
 		eventToken: tokenInput.value,
+		sourceMode: sourceModeSelect.value === "cheesy" ? "cheesy" : "fms",
+		cheesyPort: Number(cheesyPortInput.value) || 8080,
 	});
 
 	urlContainer.style.display = cloudCheckbox.checked ? "none" : "block";
 	signalRRow.style.display = fieldMonitorInput.checked ? "flex" : "none";
+	cheesyPortRow.style.display = sourceModeSelect.value === "cheesy" ? "flex" : "none";
 	// Storage change triggers background restart automatically
 }
 
@@ -247,7 +260,9 @@ function updatePopup(
 		| "useSignalR"
 		| "fmsApiEnabled"
 		| "event"
-		| "eventToken",
+		| "eventToken"
+		| "sourceMode"
+		| "cheesyPort",
 	value: boolean | string,
 ) {
 	const elm = document?.getElementById(setting);
@@ -255,11 +270,15 @@ function updatePopup(
 	if (typeof value === "boolean") {
 		(elm as HTMLInputElement).checked = value;
 	} else {
-		(elm as HTMLInputElement).value = value;
+		(elm as HTMLInputElement).value = String(value);
 	}
 	// Keep the SignalR row visibility in sync
 	if (setting === "fieldMonitor") {
 		signalRRow.style.display = (value as boolean) ? "flex" : "none";
+	}
+	// Keep the Cheesy port row visibility in sync with the field system
+	if (setting === "sourceMode") {
+		cheesyPortRow.style.display = value === "cheesy" ? "flex" : "none";
 	}
 }
 
@@ -276,7 +295,9 @@ chrome.storage.local.onChanged.addListener((changes) => {
 				| "useSignalR"
 				| "fmsApiEnabled"
 				| "event"
-				| "eventToken",
+				| "eventToken"
+				| "sourceMode"
+				| "cheesyPort",
 			changes[key].newValue as string | boolean,
 		);
 	}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"app",
 		"extension"
 	],
-	"version": "2.7.9.0",
+	"version": "2.7.8.1",
 	"description": "",
 	"scripts": {
 		"start": "bun run ./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"app",
 		"extension"
 	],
-	"version": "2.7.8.0",
+	"version": "2.7.9.0",
 	"description": "",
 	"scripts": {
 		"start": "bun run ./src/index.ts",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -492,6 +492,9 @@ export interface ServerEvent {
 			ip?: string;
 			userAgent?: string;
 			connected: Date;
+			version?: string;
+			config?: ExtensionConfig;
+			fmsApi?: boolean;
 		}[];
 		clients: {
 			id: string;
@@ -500,6 +503,20 @@ export interface ServerEvent {
 			connected: Date;
 		}[];
 	};
+}
+
+/**
+ * The extension settings that can be read and changed remotely (through the
+ * server) as well as locally. Mirrors the fields the extension stores in
+ * chrome.storage.local, so any device can reconfigure a connected extension.
+ */
+export interface ExtensionConfig {
+	enabled?: boolean;
+	fieldMonitor?: boolean;
+	useSignalR?: boolean;
+	fmsApiEnabled?: boolean;
+	sourceMode?: "fms" | "cheesy";
+	cheesyPort?: number;
 }
 
 export type NotificationEvents = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { fieldMonitorRouter } from "./router/field-monitor";
 import { matchRouter } from "./router/logs";
 import { aiReportRouter } from "./router/ai-report";
 import { matchEventsRouter } from "./router/match-events";
+import { extensionRouter } from "./router/extension";
 import {
 	addNoteMessageFromSlack,
 	createFromNexus,
@@ -86,6 +87,7 @@ const appRouter = router({
 	cycles: cycleRouter,
 	notes: notesRouter,
 	matchEvents: matchEventsRouter,
+	extension: extensionRouter,
 	aiReport: aiReportRouter,
 	app: router({
 		version: publicProcedure.query(() => {

--- a/src/router/extension.ts
+++ b/src/router/extension.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+import { bus } from "../util/eventBus";
+import type { ExtensionConfig, ServerEvent } from "../../shared/types";
+import { eventProcedure, router } from "../trpc";
+import { subscriptionQueue } from "../util/subscription";
+
+const extensionConfigSchema = z.object({
+	enabled: z.boolean().optional(),
+	fieldMonitor: z.boolean().optional(),
+	useSignalR: z.boolean().optional(),
+	fmsApiEnabled: z.boolean().optional(),
+	sourceMode: z.enum(["fms", "cheesy"]).optional(),
+	cheesyPort: z.number().int().min(1).max(65535).optional(),
+});
+
+/** Bus payload for a config push from the web app to a connected extension. */
+interface ExtensionConfigPush {
+	extensionId?: string;
+	config: ExtensionConfig;
+}
+
+/** Public-facing view of a connected extension (no ip / user agent). */
+interface ExtensionSummary {
+	id: string;
+	version?: string;
+	config?: ExtensionConfig;
+	fmsApi?: boolean;
+	connected: Date;
+	lastFrame: Date;
+}
+
+function summarize(extensions: ServerEvent["stats"]["extensions"]): ExtensionSummary[] {
+	return extensions.map((e) => ({
+		id: e.id,
+		version: e.version,
+		config: e.config,
+		fmsApi: e.fmsApi,
+		connected: e.connected,
+		lastFrame: e.lastFrame,
+	}));
+}
+
+/**
+ * Remote extension configuration. The extension holds a live connection to the
+ * server, so the web app can read a connected extension's settings and change
+ * them from any device (rather than only through the browser the extension is
+ * installed in). Flow: app -> setConfig -> bus -> configSubscription -> extension
+ * applies to chrome.storage -> reportState -> app sees the confirmed state.
+ */
+export const extensionRouter = router({
+	// Extension -> server: report its current config + version so any device can
+	// see how it is set up and the management UI reflects live state.
+	reportState: eventProcedure
+		.input(
+			z.object({
+				extensionId: z.string(),
+				version: z.string().optional(),
+				fmsApi: z.boolean().optional(),
+				config: extensionConfigSchema,
+			}),
+		)
+		.mutation(({ ctx, input }) => {
+			const { event } = ctx;
+			let entry = event.stats.extensions.find((e) => e.id === input.extensionId);
+			if (!entry) {
+				entry = {
+					id: input.extensionId,
+					connected: new Date(),
+					userAgent: ctx.userAgent,
+					ip: ctx.ip,
+					lastFrame: new Date(),
+					frames: 0,
+					checklistUpdates: 0,
+				};
+				event.stats.extensions.push(entry);
+			}
+			entry.version = input.version ?? entry.version;
+			if (input.fmsApi !== undefined) entry.fmsApi = input.fmsApi;
+			entry.config = { ...entry.config, ...input.config };
+			entry.lastFrame = new Date();
+			bus.publish(`event:${event.code}:extension-state`, event.stats.extensions);
+			return { ok: true };
+		}),
+
+	// Web app -> server -> extension: push a config change. extensionId targets a
+	// single extension; omit it to broadcast to every extension on the event.
+	setConfig: eventProcedure
+		.input(
+			z.object({
+				extensionId: z.string().optional(),
+				config: extensionConfigSchema,
+			}),
+		)
+		.mutation(({ ctx, input }) => {
+			const { event } = ctx;
+			const payload: ExtensionConfigPush = { extensionId: input.extensionId, config: input.config };
+			bus.publish(`event:${event.code}:extension-config`, payload);
+			// Optimistically reflect on stored state so the UI updates right away;
+			// the extension confirms via reportState once it applies the change.
+			for (const e of event.stats.extensions) {
+				if (!input.extensionId || e.id === input.extensionId) e.config = { ...e.config, ...input.config };
+			}
+			bus.publish(`event:${event.code}:extension-state`, event.stats.extensions);
+			return { ok: true };
+		}),
+
+	// Extension listens here for config pushes targeted at it.
+	configSubscription: eventProcedure
+		.input(z.object({ extensionId: z.string() }))
+		.subscription(async function* ({ ctx, input, signal }) {
+			const { event } = ctx;
+			const { push, drain } = subscriptionQueue<ExtensionConfig>(signal!);
+			const unsub = bus.subscribe(`event:${event.code}:extension-config`, (data) => {
+				const msg = data as ExtensionConfigPush;
+				if (!msg.extensionId || msg.extensionId === input.extensionId) push(msg.config);
+			});
+			try {
+				for await (const item of drain()) yield item;
+			} finally {
+				unsub();
+			}
+		}),
+
+	// Web app: the extensions currently connected to this event, with their config.
+	list: eventProcedure.query(({ ctx }) => summarize(ctx.event.stats.extensions)),
+
+	// Web app: live updates of the connected extensions (config, version, FMS status).
+	statusSubscription: eventProcedure.subscription(async function* ({ ctx, signal }) {
+		const { event } = ctx;
+		const { push, drain } = subscriptionQueue<ExtensionSummary[]>(signal!);
+		push(summarize(event.stats.extensions));
+		const unsub = bus.subscribe(`event:${event.code}:extension-state`, (data) =>
+			push(summarize(data as ServerEvent["stats"]["extensions"])),
+		);
+		const heartbeat = setInterval(() => push(summarize(event.stats.extensions)), 15_000);
+		try {
+			for await (const item of drain()) yield item;
+		} finally {
+			unsub();
+			clearInterval(heartbeat);
+		}
+	}),
+});

--- a/src/router/field-monitor.ts
+++ b/src/router/field-monitor.ts
@@ -5,7 +5,7 @@ import { bus } from "../util/eventBus";
 import { redis } from "../util/redis";
 import { formatTimeShortNoAgoSeconds } from "../../shared/formatTime";
 import { DSState, EnableState, FieldState } from "../../shared/types";
-import type { EventTiming, MonitorFrame, StateChange, TournamentLevel } from "../../shared/types";
+import type { EventTiming, ExtensionConfig, MonitorFrame, StateChange, TournamentLevel } from "../../shared/types";
 import { DEFAULT_MONITOR } from "../../shared/constants";
 import { eventProcedure, publicProcedure, resolveUserFromToken, router } from "../trpc";
 import {
@@ -435,5 +435,7 @@ export interface EventState {
 		lastFrame: Date;
 		frames: number;
 		checklistUpdates: number;
+		version?: string;
+		config?: ExtensionConfig;
 	}[];
 }


### PR DESCRIPTION
Two related extension features, bundled into one release (**ext v1.26.19**, app **2.7.9.0**).

## H - Reconfigure from any device
`/manage/event-settings` used `window.postMessage`, so it only saw the extension if it was installed in the same browser (hence the perpetual "no extension connected / scraping mode"). Config now flows through the server, which the extension is already connected to.

- **Server** (`src/router/extension.ts`): `reportState` (extension -> server: config/version/fmsApi), `setConfig` (app -> bus -> extension), `configSubscription` (extension listens), `list` + `statusSubscription` (app reads live connected extensions). Built on the existing event bus + SSE subscription rails.
- **Extension** (`background.ts`): reports its state and subscribes for config pushes; a pushed config is written to `chrome.storage.local`, and the existing restart path applies it.
- **App** (`StepEventManagement.svelte`): detects + configures via the server subscription/mutation. Shows "update the extension" for pre-1.26.19 builds that predate the remote-config channel.

## F - Full settings in the popup
The extension popup (`menu.html`/`menu.ts`) already had the toggles; added the **Field System (FMS / Cheesy Arena) select** and **Cheesy port**, so every host-wizard setting is editable locally in the popup too.

## Verified
- Server `tsc`, extension `tsc` + webpack, app `svelte-check` + `vite build`: all clean.
- Requires an extension update (needs publishing) - the `1.26.19` zip is built and ready.

Note: the remote-config path (server <-> extension over SSE/bus) is verified at compile time; a live end-to-end run against a deployed server + loaded extension is still worth a manual check.